### PR TITLE
feat: over-limit bar colour + API inspection tool for nutrition targets

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ var (
 	flagLogin  bool
 	flagLogout bool
 	flagTLD    string
+	flagRaw    bool
 	version    = "0.1.0"
 )
 
@@ -50,6 +51,8 @@ func init() {
 	rootCmd.Flags().BoolVar(&flagLogin, "login", false, "Authenticate and store credentials")
 	rootCmd.Flags().BoolVar(&flagLogout, "logout", false, "Clear stored credentials")
 	rootCmd.Flags().StringVarP(&flagTLD, "tld", "l", "com", "WW top-level domain (com, co.uk, etc.)")
+	rootCmd.Flags().BoolVar(&flagRaw, "raw", false, "Dump raw API JSON for the start date (for API inspection)")
+	_ = rootCmd.Flags().MarkHidden("raw")
 }
 
 func run(cmd *cobra.Command, _ []string) error {
@@ -91,6 +94,24 @@ func run(cmd *cobra.Command, _ []string) error {
 			msg += fmt.Sprintf(" Session expires %s.", exp.Local().Format("Mon 2 Jan 2006 at 15:04"))
 		}
 		fmt.Fprintln(os.Stderr, msg)
+		return nil
+	}
+
+	// Raw API dump for inspection (hidden flag, not shown in --help).
+	if flagRaw {
+		start := flagStart
+		if start == "" {
+			start = time.Now().Format("2006-01-02")
+		}
+		token, err := authenticator.Token()
+		if err != nil {
+			return fmt.Errorf("%w\nRun 'wwlog --login' to authenticate", err)
+		}
+		raw, err := api.New(token, tld).FetchDayRaw(start)
+		if err != nil {
+			return err
+		}
+		os.Stdout.Write(raw)
 		return nil
 	}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -103,6 +104,25 @@ func DateRange(start, end string) ([]string, error) {
 		dates = append(dates, d.Format(layout))
 	}
 	return dates, nil
+}
+
+// FetchDayRaw returns the raw JSON response body for a single date. Used for
+// API inspection — run with --raw to see all available fields.
+func (c *Client) FetchDayRaw(date string) ([]byte, error) {
+	url := fmt.Sprintf(
+		"https://cmx.weightwatchers.%s/api/v3/cmx/operations/composed/members/~/my-day/%s",
+		c.tld, date,
+	)
+	resp, err := c.get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetch raw day %s: %w", date, err)
+	}
+	defer resp.Body.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func (c *Client) get(url string) (*http.Response, error) {

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -275,7 +275,11 @@ func makeBar(value, max float64, width int) string {
 		filled = width
 	}
 	empty := width - filled
-	return lipgloss.NewStyle().Foreground(colorTeal).Render(strings.Repeat("█", filled)) +
+	barColor := colorTeal
+	if max > 0 && value > max {
+		barColor = colorPurple
+	}
+	return lipgloss.NewStyle().Foreground(barColor).Render(strings.Repeat("█", filled)) +
 		lipgloss.NewStyle().Foreground(colorSteel).Render(strings.Repeat("░", empty))
 }
 


### PR DESCRIPTION
## Summary

- Nutrition bars in the **Nutrition tab** now render in **purple** when intake exceeds the reference daily value (RDV), giving an at-a-glance signal for over-target nutrients — teal means within range, purple means over
- Adds a hidden `--raw` flag (not shown in `--help`) that dumps the raw `my-day` API JSON to stdout, needed to determine what personalised nutrition-target fields the API actually exposes

## API research needed before completing the range-marker feature

Run this to inspect the live response:

```bash
wwlog --raw --start 2026-04-29 | python3 -m json.tool | less
```

Look for fields like `nutritionTargets`, `calorieTarget`, `macroTargets`, or anything similar alongside or within `pointsDetails`. If they exist we can extend `DayPoints` and render `▲` min/max markers on the bars. If not, the RDV + purple-over-limit approach is the right permanent fallback.

## Test plan

- [ ] Build and run `wwlog` over a date range that includes a day with high sodium or fat
- [ ] Navigate to the **Nutrition** tab — any bar that exceeds 100 % of the RDV should appear in purple
- [ ] Run `wwlog --raw --start <date> | python3 -m json.tool | less` and search for any nutrition-goal fields — report back what you find

Partial implementation of #11

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)