### PR TITLE
feat: locale-aware date formatting and weight unit fallback

### DIFF
--- a/internal/tui/locale.go
+++ b/internal/tui/locale.go
@@ -1,0 +1,50 @@
+package tui
+
+import "time"
+
+// locale encapsulates TLD-derived display preferences for dates and units.
+type locale struct {
+	tld string
+}
+
+func newLocale(tld string) locale { return locale{tld: tld} }
+
+func (l locale) isUS() bool { return l.tld == "com" }
+
+// dateShort formats a YYYY-MM-DD date as a short display string.
+// US: "Mon, Jan 2"  · others: "Mon, 2 Jan"
+func (l locale) dateShort(date string) string {
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return date
+	}
+	if l.isUS() {
+		return t.Format("Mon, Jan 2")
+	}
+	return t.Format("Mon, 2 Jan")
+}
+
+// dateLong formats a YYYY-MM-DD date as a long display string.
+// US: "Monday, January 2 2006"  · others: "Monday 2 January 2006"
+func (l locale) dateLong(date string) string {
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return date
+	}
+	if l.isUS() {
+		return t.Format("Monday, January 2 2006")
+	}
+	return t.Format("Monday 2 January 2006")
+}
+
+// weightUnit returns the unit string from the API response, falling back to
+// a TLD-derived default if the API returns an empty value.
+func (l locale) weightUnit(fromAPI string) string {
+	if fromAPI != "" {
+		return fromAPI
+	}
+	if l.isUS() {
+		return "lb"
+	}
+	return "kg"
+}

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/ali5ter/wwlog/internal/api"
 	"github.com/charmbracelet/bubbles/key"
@@ -51,25 +50,27 @@ type logModel struct {
 	height      int
 	selected    int
 	sort        sortMode
+	locale      locale
 	initialized bool
 }
 
 type dateItem struct {
-	log *api.DayLog
+	log    *api.DayLog
+	locale locale
 }
 
-func (d dateItem) Title() string       { return formatDateShort(d.log.Date) }
-func (d dateItem) Description() string { return mealSummary(d.log) }
+func (d dateItem) Title() string       { return d.locale.dateShort(d.log.Date) }
+func (d dateItem) Description() string { return mealSummary(d.log, d.locale) }
 func (d dateItem) FilterValue() string { return d.log.Date }
 
-func newLogModel(logs []*api.DayLog, width, height int) logModel {
+func newLogModel(logs []*api.DayLog, width, height int, loc locale) logModel {
 	listWidth := width / 3
 	detailWidth := width - listWidth
 	listHeight := height - 2 // filter bar + separator
 
 	items := make([]list.Item, len(logs))
 	for i, l := range logs {
-		items[i] = dateItem{log: l}
+		items[i] = dateItem{log: l, locale: loc}
 	}
 
 	l := list.New(items, list.NewDefaultDelegate(), listWidth, listHeight)
@@ -95,10 +96,11 @@ func newLogModel(logs []*api.DayLog, width, height int) logModel {
 		logs:        logs,
 		width:       width,
 		height:      height,
+		locale:      loc,
 		initialized: true,
 	}
 	if len(logs) > 0 {
-		m.detail.SetContent(renderDay(logs[0], detailWidth-2, m.sort))
+		m.detail.SetContent(renderDay(logs[0], detailWidth-2, m.sort, loc))
 	}
 	return m
 }
@@ -141,7 +143,7 @@ func (m logModel) update(msg tea.Msg) (logModel, tea.Cmd) {
 			case key.Matches(msg, keys.Sort):
 				m.sort = m.sort.next()
 				if m.selected < len(m.logs) {
-					m.detail.SetContent(renderDay(m.logs[m.selected], m.detail.Width-2, m.sort))
+					m.detail.SetContent(renderDay(m.logs[m.selected], m.detail.Width-2, m.sort, m.locale))
 					m.detail.GotoTop()
 				}
 				return m, nil
@@ -155,7 +157,7 @@ func (m logModel) update(msg tea.Msg) (logModel, tea.Cmd) {
 	selChanged := false
 	if i := m.list.Index(); i != m.selected && i < len(m.logs) {
 		m.selected = i
-		m.detail.SetContent(renderDay(m.logs[i], m.detail.Width-2, m.sort))
+		m.detail.SetContent(renderDay(m.logs[i], m.detail.Width-2, m.sort, m.locale))
 		m.detail.GotoTop()
 		selChanged = true
 	}
@@ -180,19 +182,19 @@ func (m *logModel) applyFilter() {
 	for _, l := range m.allLogs {
 		if q == "" ||
 			strings.Contains(strings.ToLower(l.Date), q) ||
-			strings.Contains(strings.ToLower(formatDateShort(l.Date)), q) {
+			strings.Contains(strings.ToLower(m.locale.dateShort(l.Date)), q) {
 			filtered = append(filtered, l)
 		}
 	}
 	m.logs = filtered
 	items := make([]list.Item, len(filtered))
 	for i, l := range filtered {
-		items[i] = dateItem{log: l}
+		items[i] = dateItem{log: l, locale: m.locale}
 	}
 	m.list.SetItems(items)
 	m.selected = 0
 	if len(filtered) > 0 {
-		m.detail.SetContent(renderDay(filtered[0], m.detail.Width-2, m.sort))
+		m.detail.SetContent(renderDay(filtered[0], m.detail.Width-2, m.sort, m.locale))
 	} else {
 		m.detail.SetContent(styleFoodPortion.Render("No matching dates."))
 	}
@@ -233,11 +235,11 @@ func (m *logModel) resize(width, height int) {
 	m.detail.Width = detailWidth
 	m.detail.Height = height
 	if m.selected < len(m.logs) && len(m.logs) > 0 {
-		m.detail.SetContent(renderDay(m.logs[m.selected], detailWidth-2, m.sort))
+		m.detail.SetContent(renderDay(m.logs[m.selected], detailWidth-2, m.sort, m.locale))
 	}
 }
 
-func renderPointsSummary(b *strings.Builder, pts api.DayPoints, contentWidth int) {
+func renderPointsSummary(b *strings.Builder, pts api.DayPoints, contentWidth int, loc locale) {
 	if pts.DailyTarget == 0 {
 		return
 	}
@@ -259,7 +261,7 @@ func renderPointsSummary(b *strings.Builder, pts api.DayPoints, contentWidth int
 		meta = append(meta, fmt.Sprintf("Activity +%.0f earned", pts.ActivityEarned))
 	}
 	if pts.Weight > 0 {
-		meta = append(meta, fmt.Sprintf("Weight %.1f %s", pts.Weight, pts.WeightUnit))
+		meta = append(meta, fmt.Sprintf("Weight %.1f %s", pts.Weight, loc.weightUnit(pts.WeightUnit)))
 	}
 	if len(meta) > 0 {
 		fmt.Fprintf(b, "  %s\n", styleFoodPortion.Render(strings.Join(meta, "  ·  ")))
@@ -285,19 +287,19 @@ func sortEntries(entries []api.FoodEntry, mode sortMode) []api.FoodEntry {
 	return cp
 }
 
-func renderDay(day *api.DayLog, width int, mode sortMode) string {
+func renderDay(day *api.DayLog, width int, mode sortMode, loc locale) string {
 	var b strings.Builder
 	sepWidth := width - 2
 	if sepWidth < 1 {
 		sepWidth = 1
 	}
-	heading := formatDateLong(day.Date)
+	heading := loc.dateLong(day.Date)
 	if lbl := mode.label(); lbl != "" {
 		heading += styleFoodPortion.Render("  (" + lbl + ")")
 	}
 	fmt.Fprintf(&b, "%s\n", styleMealHeading.Render(heading))
 	fmt.Fprintf(&b, "%s\n\n", styleDim.Render(strings.Repeat("─", sepWidth)))
-	renderPointsSummary(&b, day.Points, width)
+	renderPointsSummary(&b, day.Points, width, loc)
 	renderMeal(&b, "☀  Breakfast", sortEntries(day.Meals.Morning, mode))
 	renderMeal(&b, "☁  Lunch", sortEntries(day.Meals.Midday, mode))
 	renderMeal(&b, "☽  Dinner", sortEntries(day.Meals.Evening, mode))
@@ -341,32 +343,16 @@ func entryPoints(e api.FoodEntry) float64 {
 	return math.Round(e.PointsPrecise)
 }
 
-func mealSummary(day *api.DayLog) string {
+func mealSummary(day *api.DayLog, loc locale) string {
 	pts := day.Points
 	if pts.DailyTarget == 0 {
 		return ""
 	}
 	s := fmt.Sprintf("%.0fpt / %.0fpt", pts.DailyUsed, pts.DailyTarget)
 	if pts.Weight > 0 {
-		s += fmt.Sprintf("  ·  %.1f %s", pts.Weight, pts.WeightUnit)
+		s += fmt.Sprintf("  ·  %.1f %s", pts.Weight, loc.weightUnit(pts.WeightUnit))
 	}
 	return s
-}
-
-func formatDateShort(date string) string {
-	t, err := time.Parse("2006-01-02", date)
-	if err != nil {
-		return date
-	}
-	return t.Format("Mon, 2 Jan")
-}
-
-func formatDateLong(date string) string {
-	t, err := time.Parse("2006-01-02", date)
-	if err != nil {
-		return date
-	}
-	return t.Format("Monday 2 January 2006")
 }
 
 func formatPortion(size float64) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -165,8 +165,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Nutrition is embedded in each food entry — compute synchronously, no extra API calls.
 		nutrition := api.ComputeAllNutrition(m.logs)
-		m.logModel = newLogModel(m.logs, m.width, m.contentHeight())
-		m.nutriModel = newNutriModel(m.logs, nutrition, m.width, m.contentHeight())
+		loc := newLocale(m.tld)
+		m.logModel = newLogModel(m.logs, m.width, m.contentHeight(), loc)
+		m.nutriModel = newNutriModel(m.logs, nutrition, m.width, m.contentHeight(), loc)
 		m.insightsModel = newInsightsModel(m.logs, m.width, m.contentHeight())
 		return m, nil
 

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -36,16 +36,17 @@ type nutriModel struct {
 	width       int
 	height      int
 	selected    int
+	locale      locale
 	initialized bool
 }
 
-func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width, height int) nutriModel {
+func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width, height int, loc locale) nutriModel {
 	listWidth := width / 3
 	listHeight := height - 2
 
 	items := make([]list.Item, len(logs))
 	for i, l := range logs {
-		items[i] = dateItem{log: l}
+		items[i] = dateItem{log: l, locale: loc}
 	}
 
 	l := list.New(items, list.NewDefaultDelegate(), listWidth, listHeight)
@@ -65,6 +66,7 @@ func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width,
 		avgs:        computeAverages(data, logs),
 		width:       width,
 		height:      height,
+		locale:      loc,
 		initialized: true,
 	}
 	m.detail.SetContent(m.renderDetail())
@@ -158,11 +160,11 @@ func (m *nutriModel) renderDetail() string {
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\n", styleMealHeading.Render(formatDateLong(day.Date)))
+	fmt.Fprintf(&b, "%s\n", styleMealHeading.Render(m.locale.dateLong(day.Date)))
 	fmt.Fprintf(&b, "%s\n\n", styleDim.Render(strings.Repeat("─", sepWidth)))
 
 	// Points summary.
-	renderPointsSummary(&b, day.Points, vw)
+	renderPointsSummary(&b, day.Points, vw, m.locale)
 
 	fmt.Fprintf(&b, "%s\n\n", styleDim.Render(strings.Repeat("─", sepWidth)))
 


### PR DESCRIPTION
## Summary

- Adds a `locale` type derived from the `--tld` flag
- **US (`com`):** dates shown in month-first order — `Mon, Jan 2` / `Monday, January 2 2006`
- **All other TLDs:** existing day-first format — `Mon, 2 Jan` / `Monday 2 January 2006`
- Weight unit falls back to `lb` (US) or `kg` (others) when the API returns an empty string; when the API does provide a unit (e.g. `lb`, `kg`, `stone`) it is used verbatim
- Locale is threaded into `logModel`, `nutriModel`, and `dateItem` so all date and weight display points are consistent
- Removed the now-unused `formatDateShort` / `formatDateLong` package-level helpers

## Test plan

- [ ] Build and run with default `--tld com` (US) — date list and detail headings should show `Mon, Jan 2` style
- [ ] Build and run with `--tld co.uk` — dates should show `Mon, 2 Jan` style
- [ ] Confirm weight display in the Log detail and date list subtitle is correct for your account
- [ ] Filter by date still works (filter matches against the locale-formatted date string)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)