### PR TITLE
fix: TUI fit & finish — ESC, selection colour, hints, trends, version check, FUNDING

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [ali5ter]

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -106,6 +106,24 @@ func DateRange(start, end string) ([]string, error) {
 	return dates, nil
 }
 
+// FetchLatestVersion hits the GitHub Releases API and returns the latest
+// published version tag (without the leading "v"), e.g. "1.2.3".
+// Returns an empty string on any error so callers can treat it as optional.
+func FetchLatestVersion() string {
+	resp, err := http.Get("https://api.github.com/repos/ali5ter/wwlog/releases/latest")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	var v struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return ""
+	}
+	return strings.TrimPrefix(v.TagName, "v")
+}
+
 // FetchDayRaw returns the raw JSON response body for a single date. Used for
 // API inspection — run with --raw to see all available fields.
 func (c *Client) FetchDayRaw(date string) ([]byte, error) {

--- a/internal/tui/locale.go
+++ b/internal/tui/locale.go
@@ -1,0 +1,50 @@
+package tui
+
+import "time"
+
+// locale encapsulates TLD-derived display preferences for dates and units.
+type locale struct {
+	tld string
+}
+
+func newLocale(tld string) locale { return locale{tld: tld} }
+
+func (l locale) isUS() bool { return l.tld == "com" }
+
+// dateShort formats a YYYY-MM-DD date as a short display string.
+// US: "Mon, Jan 2"  · others: "Mon, 2 Jan"
+func (l locale) dateShort(date string) string {
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return date
+	}
+	if l.isUS() {
+		return t.Format("Mon, Jan 2")
+	}
+	return t.Format("Mon, 2 Jan")
+}
+
+// dateLong formats a YYYY-MM-DD date as a long display string.
+// US: "Monday, January 2 2006"  · others: "Monday 2 January 2006"
+func (l locale) dateLong(date string) string {
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return date
+	}
+	if l.isUS() {
+		return t.Format("Monday, January 2 2006")
+	}
+	return t.Format("Monday 2 January 2006")
+}
+
+// weightUnit returns the unit string from the API response, falling back to
+// a TLD-derived default if the API returns an empty value.
+func (l locale) weightUnit(fromAPI string) string {
+	if fromAPI != "" {
+		return fromAPI
+	}
+	if l.isUS() {
+		return "lb"
+	}
+	return "kg"
+}

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -73,12 +73,7 @@ func newLogModel(logs []*api.DayLog, width, height int, loc locale) logModel {
 		items[i] = dateItem{log: l, locale: loc}
 	}
 
-	l := list.New(items, list.NewDefaultDelegate(), listWidth, listHeight)
-	l.Title = "Dates"
-	l.Styles.Title = styleMealHeading
-	l.SetShowStatusBar(false)
-	l.SetShowHelp(false)
-	l.SetFilteringEnabled(false)
+	l := newDateList(items, listWidth, listHeight)
 
 	fi := textinput.New()
 	fi.Placeholder = "filter by date (e.g. Jan, 04)"

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/ali5ter/wwlog/internal/api"
 	"github.com/charmbracelet/bubbles/key"
@@ -51,25 +50,27 @@ type logModel struct {
 	height      int
 	selected    int
 	sort        sortMode
+	locale      locale
 	initialized bool
 }
 
 type dateItem struct {
-	log *api.DayLog
+	log    *api.DayLog
+	locale locale
 }
 
-func (d dateItem) Title() string       { return formatDateShort(d.log.Date) }
-func (d dateItem) Description() string { return mealSummary(d.log) }
+func (d dateItem) Title() string       { return d.locale.dateShort(d.log.Date) }
+func (d dateItem) Description() string { return mealSummary(d.log, d.locale) }
 func (d dateItem) FilterValue() string { return d.log.Date }
 
-func newLogModel(logs []*api.DayLog, width, height int) logModel {
+func newLogModel(logs []*api.DayLog, width, height int, loc locale) logModel {
 	listWidth := width / 3
 	detailWidth := width - listWidth
 	listHeight := height - 2 // filter bar + separator
 
 	items := make([]list.Item, len(logs))
 	for i, l := range logs {
-		items[i] = dateItem{log: l}
+		items[i] = dateItem{log: l, locale: loc}
 	}
 
 	l := list.New(items, list.NewDefaultDelegate(), listWidth, listHeight)
@@ -95,10 +96,11 @@ func newLogModel(logs []*api.DayLog, width, height int) logModel {
 		logs:        logs,
 		width:       width,
 		height:      height,
+		locale:      loc,
 		initialized: true,
 	}
 	if len(logs) > 0 {
-		m.detail.SetContent(renderDay(logs[0], detailWidth-2, m.sort))
+		m.detail.SetContent(renderDay(logs[0], detailWidth-2, m.sort, loc))
 	}
 	return m
 }
@@ -141,7 +143,7 @@ func (m logModel) update(msg tea.Msg) (logModel, tea.Cmd) {
 			case key.Matches(msg, keys.Sort):
 				m.sort = m.sort.next()
 				if m.selected < len(m.logs) {
-					m.detail.SetContent(renderDay(m.logs[m.selected], m.detail.Width-2, m.sort))
+					m.detail.SetContent(renderDay(m.logs[m.selected], m.detail.Width-2, m.sort, m.locale))
 					m.detail.GotoTop()
 				}
 				return m, nil
@@ -155,7 +157,7 @@ func (m logModel) update(msg tea.Msg) (logModel, tea.Cmd) {
 	selChanged := false
 	if i := m.list.Index(); i != m.selected && i < len(m.logs) {
 		m.selected = i
-		m.detail.SetContent(renderDay(m.logs[i], m.detail.Width-2, m.sort))
+		m.detail.SetContent(renderDay(m.logs[i], m.detail.Width-2, m.sort, m.locale))
 		m.detail.GotoTop()
 		selChanged = true
 	}
@@ -180,19 +182,19 @@ func (m *logModel) applyFilter() {
 	for _, l := range m.allLogs {
 		if q == "" ||
 			strings.Contains(strings.ToLower(l.Date), q) ||
-			strings.Contains(strings.ToLower(formatDateShort(l.Date)), q) {
+			strings.Contains(strings.ToLower(m.locale.dateShort(l.Date)), q) {
 			filtered = append(filtered, l)
 		}
 	}
 	m.logs = filtered
 	items := make([]list.Item, len(filtered))
 	for i, l := range filtered {
-		items[i] = dateItem{log: l}
+		items[i] = dateItem{log: l, locale: m.locale}
 	}
 	m.list.SetItems(items)
 	m.selected = 0
 	if len(filtered) > 0 {
-		m.detail.SetContent(renderDay(filtered[0], m.detail.Width-2, m.sort))
+		m.detail.SetContent(renderDay(filtered[0], m.detail.Width-2, m.sort, m.locale))
 	} else {
 		m.detail.SetContent(styleFoodPortion.Render("No matching dates."))
 	}
@@ -233,11 +235,11 @@ func (m *logModel) resize(width, height int) {
 	m.detail.Width = detailWidth
 	m.detail.Height = height
 	if m.selected < len(m.logs) && len(m.logs) > 0 {
-		m.detail.SetContent(renderDay(m.logs[m.selected], detailWidth-2, m.sort))
+		m.detail.SetContent(renderDay(m.logs[m.selected], detailWidth-2, m.sort, m.locale))
 	}
 }
 
-func renderPointsSummary(b *strings.Builder, pts api.DayPoints, contentWidth int) {
+func renderPointsSummary(b *strings.Builder, pts api.DayPoints, contentWidth int, loc locale) {
 	if pts.DailyTarget == 0 {
 		return
 	}
@@ -259,7 +261,7 @@ func renderPointsSummary(b *strings.Builder, pts api.DayPoints, contentWidth int
 		meta = append(meta, fmt.Sprintf("Activity +%.0f earned", pts.ActivityEarned))
 	}
 	if pts.Weight > 0 {
-		meta = append(meta, fmt.Sprintf("Weight %.1f %s", pts.Weight, pts.WeightUnit))
+		meta = append(meta, fmt.Sprintf("Weight %.1f %s", pts.Weight, loc.weightUnit(pts.WeightUnit)))
 	}
 	if len(meta) > 0 {
 		fmt.Fprintf(b, "  %s\n", styleFoodPortion.Render(strings.Join(meta, "  ·  ")))
@@ -285,19 +287,19 @@ func sortEntries(entries []api.FoodEntry, mode sortMode) []api.FoodEntry {
 	return cp
 }
 
-func renderDay(day *api.DayLog, width int, mode sortMode) string {
+func renderDay(day *api.DayLog, width int, mode sortMode, loc locale) string {
 	var b strings.Builder
 	sepWidth := width - 2
 	if sepWidth < 1 {
 		sepWidth = 1
 	}
-	heading := formatDateLong(day.Date)
+	heading := loc.dateLong(day.Date)
 	if lbl := mode.label(); lbl != "" {
 		heading += styleFoodPortion.Render("  (" + lbl + ")")
 	}
 	fmt.Fprintf(&b, "%s\n", styleMealHeading.Render(heading))
 	fmt.Fprintf(&b, "%s\n\n", styleDim.Render(strings.Repeat("─", sepWidth)))
-	renderPointsSummary(&b, day.Points, width)
+	renderPointsSummary(&b, day.Points, width, loc)
 	renderMeal(&b, "☀  Breakfast", sortEntries(day.Meals.Morning, mode))
 	renderMeal(&b, "☁  Lunch", sortEntries(day.Meals.Midday, mode))
 	renderMeal(&b, "☽  Dinner", sortEntries(day.Meals.Evening, mode))
@@ -341,32 +343,16 @@ func entryPoints(e api.FoodEntry) float64 {
 	return math.Round(e.PointsPrecise)
 }
 
-func mealSummary(day *api.DayLog) string {
+func mealSummary(day *api.DayLog, loc locale) string {
 	pts := day.Points
 	if pts.DailyTarget == 0 {
 		return ""
 	}
 	s := fmt.Sprintf("%.0fpt / %.0fpt", pts.DailyUsed, pts.DailyTarget)
 	if pts.Weight > 0 {
-		s += fmt.Sprintf("  ·  %.1f %s", pts.Weight, pts.WeightUnit)
+		s += fmt.Sprintf("  ·  %.1f %s", pts.Weight, loc.weightUnit(pts.WeightUnit))
 	}
 	return s
-}
-
-func formatDateShort(date string) string {
-	t, err := time.Parse("2006-01-02", date)
-	if err != nil {
-		return date
-	}
-	return t.Format("Mon, 2 Jan")
-}
-
-func formatDateLong(date string) string {
-	t, err := time.Parse("2006-01-02", date)
-	if err != nil {
-		return date
-	}
-	return t.Format("Monday 2 January 2006")
 }
 
 func formatPortion(size float64) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -165,8 +165,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Nutrition is embedded in each food entry — compute synchronously, no extra API calls.
 		nutrition := api.ComputeAllNutrition(m.logs)
-		m.logModel = newLogModel(m.logs, m.width, m.contentHeight())
-		m.nutriModel = newNutriModel(m.logs, nutrition, m.width, m.contentHeight())
+		loc := newLocale(m.tld)
+		m.logModel = newLogModel(m.logs, m.width, m.contentHeight(), loc)
+		m.nutriModel = newNutriModel(m.logs, nutrition, m.width, m.contentHeight(), loc)
 		m.insightsModel = newInsightsModel(m.logs, m.width, m.contentHeight())
 		return m, nil
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -40,6 +40,8 @@ type dataMsg struct {
 	err    error
 }
 
+type versionMsg struct{ latest string }
+
 // Tab-contextual footer animations.
 var (
 	animLogSpinner = spinner.Spinner{
@@ -73,12 +75,13 @@ type Model struct {
 	exportModel     exportModel
 	dateRangeModel  dateRangeModel
 	authObj         *auth.Auth
-	tld         string
-	start       string
-	end         string
-	version     string
-	client      *api.Client
-	statusMsg   string
+	tld           string
+	start         string
+	end           string
+	version       string
+	latestVersion string
+	client        *api.Client
+	statusMsg     string
 }
 
 // Run initialises and starts the TUI, blocking until the user quits.
@@ -143,15 +146,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		tld := m.tld
 		start := msg.start
 		end := msg.end
-		return m, func() tea.Msg {
-			token, err := authObj.Token()
-			if err != nil {
-				return dataMsg{err: err}
-			}
-			client := api.New(token, tld)
-			logs, err := fetchLogs(client, start, end)
-			return dataMsg{logs: logs, client: client, err: err}
-		}
+		return m, tea.Batch(
+			func() tea.Msg {
+				token, err := authObj.Token()
+				if err != nil {
+					return dataMsg{err: err}
+				}
+				client := api.New(token, tld)
+				logs, err := fetchLogs(client, start, end)
+				return dataMsg{logs: logs, client: client, err: err}
+			},
+			func() tea.Msg { return versionMsg{latest: api.FetchLatestVersion()} },
+		)
 
 	case dataMsg:
 		m.loading = false
@@ -169,6 +175,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.logModel = newLogModel(m.logs, m.width, m.contentHeight(), loc)
 		m.nutriModel = newNutriModel(m.logs, nutrition, m.width, m.contentHeight(), loc)
 		m.insightsModel = newInsightsModel(m.logs, m.width, m.contentHeight())
+		return m, nil
+
+	case versionMsg:
+		m.latestVersion = msg.latest
 		return m, nil
 
 	case exportDoneMsg:
@@ -416,23 +426,37 @@ func (m Model) statusView() string {
 	hints := []string{
 		styleStatusKey.Render("↑/↓") + " navigate",
 		styleStatusKey.Render("⇧↑/↓") + " scroll",
-		styleStatusKey.Render("/") + " filter",
-		styleStatusKey.Render("r") + " range",
-		styleStatusKey.Render("s") + " sort",
-		styleStatusKey.Render("e") + " export",
-		styleStatusKey.Render("tab") + " switch",
-		styleStatusKey.Render("q") + " quit",
 	}
+	if m.activeTab == tabLog {
+		hints = append(hints, styleStatusKey.Render("/")+" filter")
+	}
+	hints = append(hints,
+		styleStatusKey.Render("r")+" range",
+		styleStatusKey.Render("s")+" sort",
+		styleStatusKey.Render("e")+" export",
+		styleStatusKey.Render("tab")+" switch",
+		styleStatusKey.Render("q")+" quit",
+	)
 	left := strings.Join(hints, "  ")
 
-	var anim string
-	switch m.activeTab {
-	case tabLog:
-		anim = m.animLog.View()
-	case tabNutrition:
-		anim = m.animNutrition.View()
+	var right string
+	currentNorm := strings.TrimPrefix(m.version, "v")
+	if m.latestVersion != "" && m.latestVersion != currentNorm {
+		right = lipgloss.NewStyle().
+			Background(colorTeal).
+			Foreground(colorPanel).
+			Padding(0, 1).
+			Render("↑ v" + m.latestVersion + " available")
+	} else {
+		var anim string
+		switch m.activeTab {
+		case tabLog:
+			anim = m.animLog.View()
+		case tabNutrition:
+			anim = m.animNutrition.View()
+		}
+		right = lipgloss.NewStyle().Foreground(colorSteel).Render(anim)
 	}
-	right := lipgloss.NewStyle().Foreground(colorSteel).Render(anim)
 
 	contentWidth := m.width - 2
 	gap := contentWidth - lipgloss.Width(left) - lipgloss.Width(right)

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -36,16 +36,17 @@ type nutriModel struct {
 	width       int
 	height      int
 	selected    int
+	locale      locale
 	initialized bool
 }
 
-func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width, height int) nutriModel {
+func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width, height int, loc locale) nutriModel {
 	listWidth := width / 3
 	listHeight := height - 2
 
 	items := make([]list.Item, len(logs))
 	for i, l := range logs {
-		items[i] = dateItem{log: l}
+		items[i] = dateItem{log: l, locale: loc}
 	}
 
 	l := list.New(items, list.NewDefaultDelegate(), listWidth, listHeight)
@@ -65,6 +66,7 @@ func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width,
 		avgs:        computeAverages(data, logs),
 		width:       width,
 		height:      height,
+		locale:      loc,
 		initialized: true,
 	}
 	m.detail.SetContent(m.renderDetail())
@@ -158,11 +160,11 @@ func (m *nutriModel) renderDetail() string {
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\n", styleMealHeading.Render(formatDateLong(day.Date)))
+	fmt.Fprintf(&b, "%s\n", styleMealHeading.Render(m.locale.dateLong(day.Date)))
 	fmt.Fprintf(&b, "%s\n\n", styleDim.Render(strings.Repeat("─", sepWidth)))
 
 	// Points summary.
-	renderPointsSummary(&b, day.Points, vw)
+	renderPointsSummary(&b, day.Points, vw, m.locale)
 
 	fmt.Fprintf(&b, "%s\n\n", styleDim.Render(strings.Repeat("─", sepWidth)))
 

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -49,12 +49,7 @@ func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width,
 		items[i] = dateItem{log: l, locale: loc}
 	}
 
-	l := list.New(items, list.NewDefaultDelegate(), listWidth, listHeight)
-	l.Title = "Dates"
-	l.Styles.Title = styleMealHeading
-	l.SetShowStatusBar(false)
-	l.SetShowHelp(false)
-	l.SetFilteringEnabled(false)
+	l := newDateList(items, listWidth, listHeight)
 
 	vp := viewport.New(width-listWidth, height)
 
@@ -241,6 +236,7 @@ func writeTrendTable(b *strings.Builder, logs []*api.DayLog, data map[string]*ap
 		}
 		return d
 	}
+	ticks := min(n, 7) // cap so labels don't crowd on wide date ranges
 
 	for _, m := range metrics {
 		vals := make([]float64, n)
@@ -258,7 +254,7 @@ func writeTrendTable(b *strings.Builder, logs []*api.DayLog, data map[string]*ap
 			asciigraph.Caption(fmt.Sprintf("%s (%s)", m.label, m.unit)),
 			asciigraph.CaptionColor(asciigraph.LightSlateGray),
 			asciigraph.XAxisRange(0, float64(n-1)),
-			asciigraph.XAxisTickCount(n),
+			asciigraph.XAxisTickCount(ticks),
 			asciigraph.XAxisValueFormatter(dateLabel),
 		)
 		fmt.Fprintf(b, "%s\n\n", chart)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -5,8 +5,33 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// newDateList returns a list.Model pre-configured with the WW palette and the
+// app's key-binding policy (list quit disabled — the top-level model owns it).
+func newDateList(items []list.Item, width, height int) list.Model {
+	del := list.NewDefaultDelegate()
+	del.Styles.NormalTitle = lipgloss.NewStyle().Foreground(colorText).Padding(0, 0, 0, 2)
+	del.Styles.NormalDesc = del.Styles.NormalTitle.Foreground(colorMuted)
+	del.Styles.SelectedTitle = lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, false, true).
+		BorderForeground(colorTeal).
+		Foreground(colorTeal).
+		Padding(0, 0, 0, 1)
+	del.Styles.SelectedDesc = del.Styles.SelectedTitle.Foreground(colorMuted)
+
+	l := list.New(items, del, width, height)
+	l.Title = "Dates"
+	l.Styles.Title = styleMealHeading
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(false)
+	l.SetFilteringEnabled(false)
+	l.KeyMap.Quit = key.NewBinding() // top-level model handles q and ctrl+c
+	return l
+}
 
 func truncate(s string, max int) string {
 	r := []rune(s)


### PR DESCRIPTION
## Summary

Six items from Issue #17:

| # | Item | Fix |
|---|------|-----|
| 1 | ESC closes the TUI | Disabled `bubbles/list` default `Quit` binding (which includes `esc`); top-level model owns `q`/`ctrl+c` |
| 2 | Selection colour inconsistent across tabs | Centralised list construction into `newDateList()` so Log and Nutrition tabs share identical WW-palette styles (teal left border, teal title text) |
| 3 | `/` filter hint shows on wrong tabs | Status bar now only renders the `/` hint when the Log tab is active |
| 4 | Trend charts crowded at 30-day range | X-axis tick count capped at 7 regardless of range length |
| 5 | Version check | `FetchLatestVersion()` hits GitHub Releases API in the background; teal `↑ vX.Y.Z available` badge appears in the status bar when a newer release exists |
| 6 | FUNDING.yml | Added `.github/FUNDING.yml` for GitHub Sponsors (`ali5ter`) |

## Test plan

- [ ] Press `esc` anywhere on the main log screen — TUI should NOT quit
- [ ] Compare selection highlight colour in Log tab vs Nutrition tab date list — should both be teal
- [ ] Switch to Nutrition or Insights tab — `/` should not appear in the status bar hints
- [ ] Run over a 30-day date range, open Nutrition tab, scroll to Trends — X-axis should show ≤ 7 evenly-spaced date labels
- [ ] Temporarily set `version = "0.0.1"` in `cmd/root.go`, build, and run — status bar should show the teal `↑ vX.Y.Z available` badge
- [ ] Check repo page for Sponsor button after merge

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)