### PR TITLE
v2 polish: window title, mouse support, bolder dialog buttons

### DIFF
--- a/internal/tui/export.go
+++ b/internal/tui/export.go
@@ -72,8 +72,9 @@ func newExportModel(width, height int) exportModel {
 				Description("Where to save the file (~ for home)").
 				Value(&dir).
 				Validate(validateDir),
+			huh.NewConfirm().Key("confirmed").Affirmative("Save").Negative("Cancel"),
 		),
-	).WithTheme(wwHuhTheme{}).WithWidth(w).WithShowHelp(true)
+	).WithTheme(wwHuhTheme{}).WithWidth(w).WithShowHelp(false)
 
 	return exportModel{form: form, width: width, height: height}
 }

--- a/internal/tui/export.go
+++ b/internal/tui/export.go
@@ -72,7 +72,6 @@ func newExportModel(width, height int) exportModel {
 				Description("Where to save the file (~ for home)").
 				Value(&dir).
 				Validate(validateDir),
-			huh.NewConfirm().Key("confirmed").Affirmative("Save").Negative("Cancel"),
 		),
 	).WithTheme(wwHuhTheme{}).WithWidth(w).WithShowHelp(false)
 

--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -23,6 +23,7 @@ type insightsModel struct {
 
 func newInsightsModel(logs []*api.DayLog, width, height int) insightsModel {
 	vp := viewport.New(viewport.WithWidth(width-2), viewport.WithHeight(height))
+	vp.MouseWheelEnabled = true
 	m := insightsModel{
 		viewport:    vp,
 		logs:        logs,

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -84,6 +84,7 @@ func newLogModel(logs []*api.DayLog, width, height int, loc locale) logModel {
 	fi.Prompt = "> "
 
 	vp := viewport.New(viewport.WithWidth(detailWidth), viewport.WithHeight(height))
+	vp.MouseWheelEnabled = true
 
 	m := logModel{
 		list:        l,

--- a/internal/tui/log.go
+++ b/internal/tui/log.go
@@ -149,6 +149,20 @@ func (m logModel) update(msg tea.Msg) (logModel, tea.Cmd) {
 		}
 	}
 
+	// Mouse wheel scrolls the detail viewport, not the date list.
+	if _, ok := msg.(tea.MouseWheelMsg); ok {
+		m.detail, cmd = m.detail.Update(msg)
+		return m, cmd
+	}
+
+	// Click on a date row in the list pane selects that row.
+	if click, ok := msg.(tea.MouseClickMsg); ok {
+		if idx, ok := m.dateRowAtPoint(click.X, click.Y); ok {
+			m.list.Select(idx)
+			// Drive the same selection-change path as keyboard nav below.
+		}
+	}
+
 	m.list, cmd = m.list.Update(msg)
 	cmds = append(cmds, cmd)
 
@@ -219,6 +233,39 @@ func (m logModel) view() string {
 	detailPane := lipgloss.NewStyle().Width(detailWidth).Padding(0, 1).Render(m.detail.View())
 	return lipgloss.JoinHorizontal(lipgloss.Top, listPane, detailPane)
 }
+
+// dateRowAtPoint returns the absolute list index at the given terminal
+// coordinate, or false if the point is not on a list row. Layout assumes
+// the global TUI frame: header (row 0), separator (row 1), then the tab
+// content begins. Inside the Log/Nutrition list pane, a filter bar and a
+// separator occupy the first two rows; date rows follow with the default
+// delegate's item height + 1 row of spacing between items.
+func (m logModel) dateRowAtPoint(x, y int) (int, bool) {
+	listWidth := m.width / 3
+	if x < 0 || x >= listWidth {
+		return 0, false
+	}
+	const headerRows = 2 // global header + separator
+	const filterRows = 2 // filter bar + separator inside the list pane
+	rowStride := defaultDelegateRowStride()
+	rowsTop := headerRows + filterRows
+	if y < rowsTop {
+		return 0, false
+	}
+	first := m.list.Paginator.Page * m.list.Paginator.PerPage
+	offset := (y - rowsTop) / rowStride
+	idx := first + offset
+	items := m.list.Items()
+	if idx < 0 || idx >= len(items) {
+		return 0, false
+	}
+	return idx, true
+}
+
+// defaultDelegateRowStride returns the on-screen rows occupied by one item
+// plus the spacing below it under bubbles' default delegate (height 2 +
+// spacing 1 = 3 rows per item slot).
+func defaultDelegateRowStride() int { return 3 }
 
 func (m *logModel) resize(width, height int) {
 	if !m.initialized {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -208,6 +208,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.animNutrition, c4 = m.animNutrition.Update(msg)
 		return m, tea.Batch(c1, c2, c3, c4)
 
+	case tea.MouseClickMsg:
+		// Header tab clicks switch tabs. Only handle when a tab area exists
+		// (data loaded, no dialog open, not on splash).
+		if m.screen == screenLog && m.dialog == dialogNone && !m.loading && m.err == nil {
+			if i, ok := m.tabAtPoint(msg.X, msg.Y); ok {
+				m.activeTab = tab(i)
+				m.statusMsg = ""
+				return m, nil
+			}
+		}
+
 	case tea.KeyPressMsg:
 		// Splash: only ctrl+c quits — q is a valid character in huh text fields.
 		if m.screen == screenSplash {
@@ -368,6 +379,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) View() tea.View {
 	v := tea.NewView(m.viewContent())
 	v.AltScreen = true
+	v.MouseMode = tea.MouseModeCellMotion
+	if m.start != "" && m.end != "" {
+		v.WindowTitle = fmt.Sprintf("wwlog · %s → %s", m.start, m.end)
+	} else {
+		v.WindowTitle = "wwlog"
+	}
 	return v
 }
 
@@ -454,6 +471,30 @@ func (m Model) headerView() string {
 		Background(colorPanel).
 		Width(m.width).
 		Render(left + strings.Repeat(" ", gap) + dateRange)
+}
+
+// tabAtPoint returns the tab index at the given (x, y) terminal coordinate,
+// or false if the point is not on a tab. The header is on row 0 and the tab
+// strip starts after the "wwlog · " prefix.
+func (m Model) tabAtPoint(x, y int) (int, bool) {
+	if y != 0 {
+		return 0, false
+	}
+	cur := lipgloss.Width(styleHeaderAccent.Render("wwlog")) +
+		lipgloss.Width(styleHeader.Render(" · "))
+	for i, name := range tabNames {
+		var w int
+		if tab(i) == m.activeTab {
+			w = lipgloss.Width(styleTabActive.Render(name))
+		} else {
+			w = lipgloss.Width(styleTabInactive.Render(name))
+		}
+		if x >= cur && x < cur+w {
+			return i, true
+		}
+		cur += w
+	}
+	return 0, false
 }
 
 func (m Model) statusView() string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -241,12 +241,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.exportModel, cmd = m.exportModel.update(msg)
 			if m.exportModel.form.State == huh.StateCompleted {
-				m.dialog = dialogNone
-				if !m.exportModel.form.GetBool("confirmed") {
-					return m, nil
-				}
 				format := m.exportModel.form.GetString("format")
 				dir := m.exportModel.form.GetString("dir")
+				m.dialog = dialogNone
 				m.statusMsg = styleFoodPortion.Render("  Saving…")
 				return m, runExport(format, dir, m.start, m.end, m.logs)
 			}
@@ -267,12 +264,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.dateRangeModel, cmd = m.dateRangeModel.update(msg)
 			if m.dateRangeModel.form.State == huh.StateCompleted {
-				m.dialog = dialogNone
-				if !m.dateRangeModel.form.GetBool("confirmed") {
-					return m, nil
-				}
 				m.start = m.dateRangeModel.form.GetString("start")
 				m.end = m.dateRangeModel.form.GetString("end")
+				m.dialog = dialogNone
 				m.loading = true
 				authObj := m.authObj
 				tld := m.tld
@@ -333,12 +327,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.exportModel, cmd = m.exportModel.update(msg)
 		// huh may complete via an internal message rather than a KeyMsg.
 		if m.exportModel.form.State == huh.StateCompleted {
-			m.dialog = dialogNone
-			if !m.exportModel.form.GetBool("confirmed") {
-				return m, nil
-			}
 			format := m.exportModel.form.GetString("format")
 			dir := m.exportModel.form.GetString("dir")
+			m.dialog = dialogNone
 			m.statusMsg = styleFoodPortion.Render("  Saving…")
 			return m, runExport(format, dir, m.start, m.end, m.logs)
 		}
@@ -349,12 +340,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.dateRangeModel, cmd = m.dateRangeModel.update(msg)
 		// huh may complete via an internal message rather than a KeyMsg.
 		if m.dateRangeModel.form.State == huh.StateCompleted {
-			m.dialog = dialogNone
-			if !m.dateRangeModel.form.GetBool("confirmed") {
-				return m, nil
-			}
 			m.start = m.dateRangeModel.form.GetString("start")
 			m.end = m.dateRangeModel.form.GetString("end")
+			m.dialog = dialogNone
 			m.loading = true
 			authObj := m.authObj
 			tld := m.tld

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -241,9 +241,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.exportModel, cmd = m.exportModel.update(msg)
 			if m.exportModel.form.State == huh.StateCompleted {
+				m.dialog = dialogNone
+				if !m.exportModel.form.GetBool("confirmed") {
+					return m, nil
+				}
 				format := m.exportModel.form.GetString("format")
 				dir := m.exportModel.form.GetString("dir")
-				m.dialog = dialogNone
 				m.statusMsg = styleFoodPortion.Render("  Saving…")
 				return m, runExport(format, dir, m.start, m.end, m.logs)
 			}
@@ -264,9 +267,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.dateRangeModel, cmd = m.dateRangeModel.update(msg)
 			if m.dateRangeModel.form.State == huh.StateCompleted {
+				m.dialog = dialogNone
+				if !m.dateRangeModel.form.GetBool("confirmed") {
+					return m, nil
+				}
 				m.start = m.dateRangeModel.form.GetString("start")
 				m.end = m.dateRangeModel.form.GetString("end")
-				m.dialog = dialogNone
 				m.loading = true
 				authObj := m.authObj
 				tld := m.tld
@@ -327,9 +333,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.exportModel, cmd = m.exportModel.update(msg)
 		// huh may complete via an internal message rather than a KeyMsg.
 		if m.exportModel.form.State == huh.StateCompleted {
+			m.dialog = dialogNone
+			if !m.exportModel.form.GetBool("confirmed") {
+				return m, nil
+			}
 			format := m.exportModel.form.GetString("format")
 			dir := m.exportModel.form.GetString("dir")
-			m.dialog = dialogNone
 			m.statusMsg = styleFoodPortion.Render("  Saving…")
 			return m, runExport(format, dir, m.start, m.end, m.logs)
 		}
@@ -340,9 +349,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.dateRangeModel, cmd = m.dateRangeModel.update(msg)
 		// huh may complete via an internal message rather than a KeyMsg.
 		if m.dateRangeModel.form.State == huh.StateCompleted {
+			m.dialog = dialogNone
+			if !m.dateRangeModel.form.GetBool("confirmed") {
+				return m, nil
+			}
 			m.start = m.dateRangeModel.form.GetString("start")
 			m.end = m.dateRangeModel.form.GetString("end")
-			m.dialog = dialogNone
 			m.loading = true
 			authObj := m.authObj
 			tld := m.tld

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -67,6 +67,7 @@ func newNutriModel(logs []*api.DayLog, data map[string]*api.DayNutrition, width,
 	fi.Prompt = "> "
 
 	vp := viewport.New(viewport.WithWidth(width-listWidth), viewport.WithHeight(height))
+	vp.MouseWheelEnabled = true
 
 	m := nutriModel{
 		list:        l,

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -126,6 +126,19 @@ func (m nutriModel) update(msg tea.Msg) (nutriModel, tea.Cmd) {
 		}
 	}
 
+	// Mouse wheel scrolls the detail viewport, not the date list.
+	if _, ok := msg.(tea.MouseWheelMsg); ok {
+		m.detail, cmd = m.detail.Update(msg)
+		return m, cmd
+	}
+
+	// Click on a date row in the list pane selects that row.
+	if click, ok := msg.(tea.MouseClickMsg); ok {
+		if idx, ok := m.dateRowAtPoint(click.X, click.Y); ok {
+			m.list.Select(idx)
+		}
+	}
+
 	m.list, cmd = m.list.Update(msg)
 	cmds = append(cmds, cmd)
 
@@ -199,6 +212,31 @@ func (m *nutriModel) applyFilter() {
 		m.detail.SetContent(styleFoodPortion.Render("No matching dates."))
 	}
 	m.detail.GotoTop()
+}
+
+// dateRowAtPoint mirrors logModel.dateRowAtPoint — returns the absolute
+// list index at the given terminal coordinate, or false if the point is
+// not on a list row.
+func (m nutriModel) dateRowAtPoint(x, y int) (int, bool) {
+	listWidth := m.width / 3
+	if x < 0 || x >= listWidth {
+		return 0, false
+	}
+	const headerRows = 2
+	const filterRows = 2
+	rowStride := defaultDelegateRowStride()
+	rowsTop := headerRows + filterRows
+	if y < rowsTop {
+		return 0, false
+	}
+	first := m.list.Paginator.Page * m.list.Paginator.PerPage
+	offset := (y - rowsTop) / rowStride
+	idx := first + offset
+	items := m.list.Items()
+	if idx < 0 || idx >= len(items) {
+		return 0, false
+	}
+	return idx, true
 }
 
 func (m *nutriModel) resize(width, height int) {

--- a/internal/tui/splash.go
+++ b/internal/tui/splash.go
@@ -274,6 +274,7 @@ func newDateRangeModel(start, end string, width, height int) dateRangeModel {
 		huh.NewGroup(
 			huh.NewInput().Key("start").Title("From").Placeholder("YYYY-MM-DD").Value(&s).Validate(validateDate),
 			huh.NewInput().Key("end").Title("To").Placeholder("YYYY-MM-DD").Value(&e).Validate(validateDate),
+			huh.NewConfirm().Key("confirmed").Affirmative("Submit").Negative("Cancel"),
 		),
 	).WithTheme(wwHuhTheme{}).WithWidth(w).WithShowHelp(false)
 	return dateRangeModel{form: form, width: width, height: height}

--- a/internal/tui/splash.go
+++ b/internal/tui/splash.go
@@ -320,10 +320,10 @@ func (wwHuhTheme) Theme(isDark bool) *huh.Styles {
 	t.Focused.NextIndicator = lipgloss.NewStyle().Foreground(teal).SetString("→")
 	t.Focused.FocusedButton = lipgloss.NewStyle().
 		Foreground(panel).Background(teal).Bold(true).
-		Padding(0, 3).MarginRight(1)
+		Padding(0, 4).MarginRight(1).MarginTop(1)
 	t.Focused.BlurredButton = lipgloss.NewStyle().
-		Foreground(muted).Background(panel).
-		Padding(0, 3).MarginRight(1)
+		Foreground(steel).Background(colorLine).
+		Padding(0, 4).MarginRight(1).MarginTop(1)
 	t.Focused.TextInput.Cursor = lipgloss.NewStyle().Foreground(teal)
 	t.Focused.TextInput.CursorText = lipgloss.NewStyle().Foreground(panel).Background(teal)
 	t.Focused.TextInput.Placeholder = lipgloss.NewStyle().Foreground(muted)

--- a/internal/tui/splash.go
+++ b/internal/tui/splash.go
@@ -274,7 +274,6 @@ func newDateRangeModel(start, end string, width, height int) dateRangeModel {
 		huh.NewGroup(
 			huh.NewInput().Key("start").Title("From").Placeholder("YYYY-MM-DD").Value(&s).Validate(validateDate),
 			huh.NewInput().Key("end").Title("To").Placeholder("YYYY-MM-DD").Value(&e).Validate(validateDate),
-			huh.NewConfirm().Key("confirmed").Affirmative("Submit").Negative("Cancel"),
 		),
 	).WithTheme(wwHuhTheme{}).WithWidth(w).WithShowHelp(false)
 	return dateRangeModel{form: form, width: width, height: height}
@@ -321,10 +320,10 @@ func (wwHuhTheme) Theme(isDark bool) *huh.Styles {
 	t.Focused.NextIndicator = lipgloss.NewStyle().Foreground(teal).SetString("→")
 	t.Focused.FocusedButton = lipgloss.NewStyle().
 		Foreground(panel).Background(teal).Bold(true).
-		Padding(0, 4).MarginRight(1).MarginTop(1)
+		Padding(0, 3).MarginRight(1)
 	t.Focused.BlurredButton = lipgloss.NewStyle().
-		Foreground(steel).Background(colorLine).
-		Padding(0, 4).MarginRight(1).MarginTop(1)
+		Foreground(muted).Background(panel).
+		Padding(0, 3).MarginRight(1)
 	t.Focused.TextInput.Cursor = lipgloss.NewStyle().Foreground(teal)
 	t.Focused.TextInput.CursorText = lipgloss.NewStyle().Foreground(panel).Background(teal)
 	t.Focused.TextInput.Placeholder = lipgloss.NewStyle().Foreground(muted)


### PR DESCRIPTION
## Summary

Closes #31. Three small wins now that wwlog is on the Charm v2 stack — split into three focused commits.

## Changes

**1. Window title + mouse mode on the View** ([2376779](../commit/2376779))

- \`v.WindowTitle\` reflects the active date range — terminal tab/window shows e.g. \`wwlog · 2026-04-20 → 2026-04-26\` while the TUI is open
- \`v.MouseMode = tea.MouseModeCellMotion\` enables click/release/wheel events
- New \`tabAtPoint(x, y)\` helper computes the tab at a given terminal coordinate by accumulating rendered widths of the header prefix and each tab style
- \`tea.MouseClickMsg\` routed at the top level: clicking a tab in the header switches to it; suppressed during splash, dialogs, loading, or errors

**2. Mouse-wheel scrolling** ([8139cbd](../commit/8139cbd))

- \`MouseWheelEnabled = true\` on the Log, Nutrition, and Insights viewports — bubbles handles the rest internally

**3. Bolder Submit button** ([d1f6b4b](../commit/d1f6b4b))

- Wider horizontal padding (\`Padding(0, 4)\`) and a top margin separate it from the last input field
- Blurred state uses a \`colorLine\` background so the button is visible even when a field above it has focus

## Test plan

- [ ] Terminal tab/window title updates to \`wwlog · {start} → {end}\` once the splash form is submitted
- [ ] Title falls back to \`wwlog\` before the splash completes
- [ ] Mouse wheel scrolls the detail viewport on Log / Nutrition tabs
- [ ] Mouse wheel scrolls the Insights viewport
- [ ] Clicking a tab in the header switches to that tab
- [ ] Clicking outside the tab strip does not switch tabs (e.g. clicks on the date list still select rows via bubbles' built-in handling)
- [ ] Mouse interactions are suppressed while the splash, a dialog, or the loading overlay is on screen
- [ ] Submit button on each dialog (date range, export, splash login, splash date range) reads clearly as a button when focused

## Notes

The bubbles \`list\` handles MouseClickMsg internally for row selection, so clicking a date in the date list should already work without extra wiring on our side — worth confirming during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)