### PR TITLE
fix: count days as over-budget by true food-points consumed

### DIFF
--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -170,10 +170,11 @@ func ComputeRangeSummary(logs []*DayLog) RangeSummary {
 	var totalPts, totalTarget, totalCals float64
 	for _, day := range logs {
 		p := day.Points
-		totalPts += p.DailyUsed
+		consumed := day.TotalPointsConsumed()
+		totalPts += consumed
 		totalTarget += p.DailyTarget
 		if p.DailyTarget > 0 {
-			if p.DailyUsed <= p.DailyTarget {
+			if consumed <= p.DailyTarget {
 				s.DaysUnderBudget++
 			} else {
 				s.DaysOverBudget++

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -126,6 +126,19 @@ func (d *DayLog) AllEntries() []FoodEntry {
 	return entries
 }
 
+// TotalPointsConsumed sums PointsPrecise across all food entries, giving the
+// true points spent that day regardless of how WW splits consumption between
+// the daily target and the weekly allowance bucket. Points.DailyUsed from
+// the API caps at DailyTarget — overflow flows silently into
+// Points.WeeklyAllowanceUsed — so DailyUsed alone hides over-budget days.
+func (d *DayLog) TotalPointsConsumed() float64 {
+	var total float64
+	for _, e := range d.AllEntries() {
+		total += e.PointsPrecise
+	}
+	return total
+}
+
 // DayNutrition holds aggregated nutritional totals for a single day.
 type DayNutrition struct {
 	Date         string

--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -229,8 +229,11 @@ func renderHeatmap(logs []*api.DayLog, vw int) string {
 	days := make(map[string]entry, len(logs))
 	for _, log := range logs {
 		if log.Points.DailyTarget > 0 {
+			// Use TotalPointsConsumed (sum of food entries' PointsPrecise)
+			// rather than Points.DailyUsed — the latter caps at DailyTarget,
+			// hiding over-budget days that flowed into the weekly allowance.
 			days[log.Date] = entry{
-				ratio:     log.Points.DailyUsed / log.Points.DailyTarget,
+				ratio:     log.TotalPointsConsumed() / log.Points.DailyTarget,
 				hasTarget: true,
 			}
 		} else {


### PR DESCRIPTION
## Summary

Your skepticism was correct. The Insights heatmap and Range Summary both used \`Points.DailyUsed\` from the WW API to decide whether a day was on or over budget — but \`DailyUsed\` **caps at \`DailyTarget\`**. Overflow flows silently into \`Points.WeeklyAllowanceUsed\` (the cumulative weekly-bonus tracker). So a heavy-eating day always reported \`DailyUsed = DailyTarget\`, ratio = 1.00, on-budget green.

## How I verified

Probed the my-day endpoint for the last 30 days. Selected rows:

| Date | Target | DailyUsed | WeeklyUsed | Ratio (old) |
|------|--------|-----------|------------|-------------|
| 2026-05-04 | 23 | 23 | 13 | 1.00 |
| 2026-05-03 | 23 | 23 | 46 | 1.00 |
| 2026-05-02 | 23 | 23 | 46 | 1.00 |
| 2026-05-01 | 23 | 23 | 46 | 1.00 |

\`WeeklyAllowance\` was 28 in that window, so a \`WeeklyAllowanceUsed\` of 46 means the user was 18 points over their weekly bonus — but every day showed as on-budget.

## Fix

Adds \`(d *DayLog) TotalPointsConsumed() float64\` (\`internal/api/types.go\`), which sums \`PointsPrecise\` across every food entry — i.e. the actual points charged to the budget for the day, regardless of which bucket WW debits.

- \`ComputeRangeSummary\` now uses this for both the average and the on/over-budget day count
- Heatmap cell ratio (\`internal/tui/insights.go:222\`) now uses this

The Log-tab points bar and the pipeline JSON/CSV/text exports continue to show \`DailyUsed\` because that's what the WW app itself shows — only metrics that compare against the daily target switch over.

## Verification

\`go build ./...\` and \`go vet ./...\` pass.

Run on the same range as before:

\`\`\`bash
go build -o wwlog .
./wwlog --start 2026-04-29 --end 2026-05-05
# Insights tab: heatmap should now show colour variation including purple over-budget cells
# Range Summary: "Days over" should be > 0 if any week had WeeklyAllowanceUsed > WeeklyAllowance
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)