### PR TITLE
feat: heatmap blocks + fixed API window, bar right-edge marker

### DIFF
--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -241,23 +241,20 @@ func renderHeatmap(logs []*api.DayLog, vw int) string {
 		}
 	}
 
-	first, _ := time.Parse(layout, logs[0].Date)
-	last, _ := time.Parse(layout, logs[len(logs)-1].Date)
-
-	// Render only the queried [first..last] weeks. The WW my-day endpoint
-	// returns 400 for dates outside a member's tracked window, so a fixed
-	// "year-at-a-glance" canvas would be mostly grey forever — better to
-	// stay honest about what was fetched.
-	gridStart := first.AddDate(0, 0, -((int(first.Weekday())+6)%7))
-	endMon := last.AddDate(0, 0, -((int(last.Weekday())+6)%7))
-	nWeeks := int(endMon.Sub(gridStart).Hours()/(24*7)) + 1
-	if nWeeks <= 0 {
-		return ""
-	}
+	// Fixed grid: span the WW my-day endpoint's ~89-day backwards window so
+	// the heatmap is the same width regardless of the queried range.
+	// Anchored to the Monday of the current week on the right; cells outside
+	// the queried [first..last] window render as no-data grey.
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	todayStr := today.Format(layout)
+	todayMon := today.AddDate(0, 0, -((int(today.Weekday())+6)%7))
+	earliestMon := today.AddDate(0, 0, -89)
+	earliestMon = earliestMon.AddDate(0, 0, -((int(earliestMon.Weekday())+6)%7))
+	nWeeks := int(todayMon.Sub(earliestMon).Hours()/(24*7)) + 1
 
 	var weeks []time.Time
 	for i := 0; i < nWeeks; i++ {
-		weeks = append(weeks, gridStart.AddDate(0, 0, 7*i))
+		weeks = append(weeks, earliestMon.AddDate(0, 0, 7*i))
 	}
 
 	const dayLabelW = 4 // "Mon "
@@ -284,9 +281,18 @@ func renderHeatmap(logs []*api.DayLog, vw int) string {
 		colorTeal,
 	}
 
+	// Cells use the lower half block ▄ rather than the full block █ so the
+	// top half of each terminal row stays empty — that gives a visible gap
+	// between consecutive day-rows in the same week column, breaking up the
+	// "vertical bar" appearance of solid stacked cells.
 	noDataStyle := lipgloss.NewStyle().Foreground(colorLine)
 	cellFor := func(dateStr string) string {
-		blocks := strings.Repeat("█", cellW)
+		blocks := strings.Repeat("▄", cellW)
+		// Future days within the rightmost (current) week haven't happened
+		// yet — render blank rather than no-data grey.
+		if dateStr > todayStr {
+			return strings.Repeat(" ", cellW)
+		}
 		e, inRange := days[dateStr]
 		if !inRange || !e.hasTarget {
 			return noDataStyle.Render(blocks)
@@ -358,7 +364,7 @@ func renderHeatmap(logs []*api.DayLog, vw int) string {
 	// Legend: GitHub-style "Less □ ▓ ▒ ▓ ▓ More" + over-budget caveat.
 	fmt.Fprintln(&b)
 	swatch := func(c color.Color) string {
-		return lipgloss.NewStyle().Foreground(c).Render(strings.Repeat("█", cellW))
+		return lipgloss.NewStyle().Foreground(c).Render(strings.Repeat("▄", cellW))
 	}
 	fmt.Fprintf(&b, "%sLess %s %s %s %s %s More  %s over budget  %s no data",
 		strings.Repeat(" ", dayLabelW),

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -475,7 +475,7 @@ func makeBar(value, max float64, width int) string {
 	}
 
 	fillStyle := lipgloss.NewStyle().Foreground(barColor)
-	emptyStyle := lipgloss.NewStyle().Foreground(colorLine)
+	markerStyle := lipgloss.NewStyle().Foreground(colorMuted)
 
 	var b strings.Builder
 	if full > 0 {
@@ -487,8 +487,11 @@ func makeBar(value, max float64, width int) string {
 		emptyCells--
 	}
 	if emptyCells > 0 {
-		b.WriteString(emptyStyle.Render(strings.Repeat("█", emptyCells)))
+		b.WriteString(strings.Repeat(" ", emptyCells))
 	}
+	// Right-edge marker showing the bar's upper limit (max). Spans the full
+	// length regardless of fill, so the user can see "where 100% sits".
+	b.WriteString(markerStyle.Render("│"))
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary

Three Insights-tab visual refinements addressing the screenshot feedback:

### Heatmap cells read as blocks, not vertical bars

Cells now use \`▄\` (LOWER HALF BLOCK) instead of \`█\`. The top half of each terminal row stays empty, giving a visible vertical gap between consecutive day-rows in the same week column. Combined with the existing \`·\` horizontal separator between weeks, every cell is now bordered by visible empty space on top, left, and right.

### Heatmap grid is fixed-width = WW's API window

Anchored to the Monday of the current week on the right, the grid spans the my-day endpoint's ~89-day backwards window — the canvas is the same width regardless of how short the queried range was. The queried \`[first..last]\` is the coloured slice; everything else is no-data grey. Future days within the rightmost (current) week render as blank rather than no-data grey.

### Bars: right-edge marker instead of grey fill

\`makeBar\` drops the \`colorLine\` \`█\` empty fill — that was creating an awkward shade discontinuity at the boundary cell, where the partial-block rune (\`▎▍▌▋▊▉\`) has terminal-default background on its right half but the next cell is rendered \`colorLine\`. Empty cells are now plain spaces, and a \`│\` marker styled in \`colorMuted\` sits at the right edge of every bar to show "where the upper limit is".

## Verification

\`go build ./...\` and \`go vet ./...\` pass.

\`\`\`bash
go build -o wwlog .
./wwlog --start 2026-04-29 --end 2026-05-05
# Insights tab: heatmap is full ~13 weeks wide; queried week visible as the
# coloured slice on the right with the rest as no-data grey. Cells should
# read as little half-height blocks with gaps, not continuous bars.
# Nutrition / Insights bars: spaces past the fill, │ marker at the right edge.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)