### PR TITLE
feat: clamp --start to WW retention window and tolerate per-day 400

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,7 +145,10 @@ func run(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("%w\nRun 'wwlog --login' to authenticate", err)
 		}
-		logs, err := loadLogs(api.New(token, tld), start, end)
+		logs, notices, err := api.LoadRange(api.New(token, tld), start, end)
+		for _, n := range notices {
+			fmt.Fprintln(os.Stderr, "note:", n)
+		}
 		if err != nil {
 			return err
 		}
@@ -190,7 +193,10 @@ func run(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("%w\nRun 'wwlog --login' to authenticate", err)
 		}
 		client := api.New(token, tld)
-		logs, err := loadLogs(client, start, end)
+		logs, notices, err := api.LoadRange(client, start, end)
+		for _, n := range notices {
+			fmt.Fprintln(os.Stderr, "note:", n)
+		}
 		if err != nil {
 			return err
 		}
@@ -202,22 +208,6 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	// TUI mode: auth and date range handled inside the TUI.
 	return tui.Run(authenticator, tld, flagStart, flagEnd, version)
-}
-
-func loadLogs(client *api.Client, start, end string) ([]*api.DayLog, error) {
-	dates, err := api.DateRange(start, end)
-	if err != nil {
-		return nil, err
-	}
-	var logs []*api.DayLog
-	for _, date := range dates {
-		day, err := client.FetchDay(date)
-		if err != nil {
-			return nil, fmt.Errorf("fetch %s: %w", date, err)
-		}
-		logs = append(logs, day)
-	}
-	return logs, nil
 }
 
 func readPassword() (string, error) {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,11 +3,18 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 )
+
+// ErrOutOfWindow is returned by FetchDay when the WW my-day endpoint
+// responds with HTTP 400 — the server enforces a ~89-day backwards
+// retention window and rejects older dates outright. Callers can
+// errors.Is(err, ErrOutOfWindow) to skip the day instead of aborting.
+var ErrOutOfWindow = errors.New("date outside WW retention window")
 
 // Client is an authenticated WW API client.
 type Client struct {
@@ -39,6 +46,9 @@ func (c *Client) FetchDay(date string) (*DayLog, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusBadRequest {
+			return nil, fmt.Errorf("fetch day %s: %w", date, ErrOutOfWindow)
+		}
 		return nil, fmt.Errorf("fetch day %s: server returned %d", date, resp.StatusCode)
 	}
 

--- a/internal/api/window.go
+++ b/internal/api/window.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// APIWindowDays is the WW my-day endpoint's hard backwards retention window
+// in days. Verified empirically: 89 days back from today still returns 200,
+// 90 days back returns 400. Older accounts hit the same wall — it's a
+// server-side policy, not a per-account limit.
+const APIWindowDays = 89
+
+// ClampToWindow checks start and end against the WW my-day endpoint's
+// retention window and returns a usable range. If start is older than the
+// window, it is clamped forward and a user-visible notice is returned. If
+// end is also older than the window, no fetchable data exists and an error
+// is returned.
+func ClampToWindow(start, end string) (clampedStart, clampedEnd, notice string, err error) {
+	const layout = "2006-01-02"
+	// Use the local calendar date — WW's retention boundary is measured in
+	// the user's account locale, not UTC. Parsing the formatted date back
+	// gives a date-only time at UTC midnight that arithmetic is safe on.
+	today, _ := time.Parse(layout, time.Now().Format(layout))
+	earliest := today.AddDate(0, 0, -APIWindowDays)
+
+	s, err := time.Parse(layout, start)
+	if err != nil {
+		return start, end, "", fmt.Errorf("invalid start date %q: %w", start, err)
+	}
+	e, err := time.Parse(layout, end)
+	if err != nil {
+		return start, end, "", fmt.Errorf("invalid end date %q: %w", end, err)
+	}
+	if e.Before(earliest) {
+		return start, end, "", fmt.Errorf(
+			"end date %s is older than WW's ~90-day retention window (earliest queryable: %s)",
+			end, earliest.Format(layout),
+		)
+	}
+	if s.Before(earliest) {
+		earliestStr := earliest.Format(layout)
+		return earliestStr, end,
+			fmt.Sprintf("--start clamped to %s (WW retains ~90 days)", earliestStr), nil
+	}
+	return start, end, "", nil
+}
+
+// LoadRange fetches every date in [start, end] from the WW API. The range
+// is first clamped to the retention window via ClampToWindow. Per-day 400
+// responses (ErrOutOfWindow) are skipped and aggregated into a single
+// summary notice. Other errors abort.
+//
+// Notices are user-visible info messages — print to stderr in pipeline
+// mode or surface in the TUI status bar.
+func LoadRange(client *Client, start, end string) (logs []*DayLog, notices []string, err error) {
+	cs, ce, clampNotice, err := ClampToWindow(start, end)
+	if err != nil {
+		return nil, nil, err
+	}
+	if clampNotice != "" {
+		notices = append(notices, clampNotice)
+	}
+
+	dates, err := DateRange(cs, ce)
+	if err != nil {
+		return nil, notices, err
+	}
+	var skipped int
+	for _, date := range dates {
+		day, err := client.FetchDay(date)
+		if err != nil {
+			if errors.Is(err, ErrOutOfWindow) {
+				skipped++
+				continue
+			}
+			return nil, notices, fmt.Errorf("fetch %s: %w", date, err)
+		}
+		logs = append(logs, day)
+	}
+	if skipped > 0 {
+		notices = append(notices, fmt.Sprintf(
+			"skipped %d day(s) outside WW retention window", skipped,
+		))
+	}
+	return logs, notices, nil
+}

--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -241,14 +241,15 @@ func renderHeatmap(logs []*api.DayLog, vw int) string {
 		}
 	}
 
-	// Fixed grid: span the WW my-day endpoint's ~89-day backwards window so
-	// the heatmap is the same width regardless of the queried range.
-	// Anchored to the Monday of the current week on the right; cells outside
-	// the queried [first..last] window render as no-data grey.
-	today := time.Now().UTC().Truncate(24 * time.Hour)
+	// Fixed grid: span the WW my-day endpoint's retention window so the
+	// heatmap is the same width regardless of the queried range. Anchored
+	// to the Monday of the current week on the right; cells outside the
+	// queried [first..last] window render as no-data grey. Uses the local
+	// calendar date — matches api.ClampToWindow's boundary logic.
+	today, _ := time.Parse(layout, time.Now().Format(layout))
 	todayStr := today.Format(layout)
 	todayMon := today.AddDate(0, 0, -((int(today.Weekday())+6)%7))
-	earliestMon := today.AddDate(0, 0, -89)
+	earliestMon := today.AddDate(0, 0, -api.APIWindowDays)
 	earliestMon = earliestMon.AddDate(0, 0, -((int(earliestMon.Weekday())+6)%7))
 	nWeeks := int(todayMon.Sub(earliestMon).Hours()/(24*7)) + 1
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -43,9 +43,10 @@ const (
 var tabNames = []string{"Log", "Nutrition", "Insights"}
 
 type dataMsg struct {
-	logs   []*api.DayLog
-	client *api.Client
-	err    error
+	logs    []*api.DayLog
+	client  *api.Client
+	notices []string
+	err     error
 }
 
 type versionMsg struct{ latest string }
@@ -162,8 +163,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return dataMsg{err: err}
 				}
 				client := api.New(token, tld)
-				logs, err := fetchLogs(client, start, end)
-				return dataMsg{logs: logs, client: client, err: err}
+				logs, notices, err := api.LoadRange(client, start, end)
+				return dataMsg{logs: logs, client: client, notices: notices, err: err}
 			},
 			func() tea.Msg { return versionMsg{latest: api.FetchLatestVersion()} },
 		)
@@ -177,6 +178,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.logs = msg.logs
 		if msg.client != nil {
 			m.client = msg.client
+		}
+		if len(msg.notices) > 0 {
+			m.statusMsg = styleFoodPortion.Render("  " + strings.Join(msg.notices, " · "))
 		}
 		// Nutrition is embedded in each food entry — compute synchronously, no extra API calls.
 		nutrition := api.ComputeAllNutrition(m.logs)
@@ -278,8 +282,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return dataMsg{err: err}
 					}
 					client := api.New(token, tld)
-					logs, err := fetchLogs(client, start, end)
-					return dataMsg{logs: logs, client: client, err: err}
+					logs, notices, err := api.LoadRange(client, start, end)
+					return dataMsg{logs: logs, client: client, notices: notices, err: err}
 				}
 			}
 			if m.dateRangeModel.form.State == huh.StateAborted {
@@ -353,8 +357,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return dataMsg{err: err}
 				}
 				client := api.New(token, tld)
-				logs, err := fetchLogs(client, start, end)
-				return dataMsg{logs: logs, client: client, err: err}
+				logs, notices, err := api.LoadRange(client, start, end)
+				return dataMsg{logs: logs, client: client, notices: notices, err: err}
 			}
 		}
 		return m, cmd
@@ -558,22 +562,6 @@ func (m Model) contentView() string {
 
 func (m Model) contentHeight() int {
 	return m.height - 4 // header + sep + sep + status
-}
-
-func fetchLogs(client *api.Client, start, end string) ([]*api.DayLog, error) {
-	dates, err := api.DateRange(start, end)
-	if err != nil {
-		return nil, err
-	}
-	var logs []*api.DayLog
-	for _, date := range dates {
-		day, err := client.FetchDay(date)
-		if err != nil {
-			return nil, fmt.Errorf("fetch %s: %w", date, err)
-		}
-		logs = append(logs, day)
-	}
-	return logs, nil
 }
 
 func max(a, b int) int {


### PR DESCRIPTION
## Summary

Addresses #38 + #39 together — they're complementary so shipping them as one PR.

The WW my-day endpoint enforces a hard 89-day backwards retention window. Anything older returns HTTP 400 (verified empirically: 2026-02-05 → 200, 2026-02-04 → 400). Today wwlog treats that 400 as a fatal error and aborts the whole range, so \`--start 2026-02-01 --end 2026-05-05\` fails outright on the first out-of-window day even though most of the range is fetchable.

## Changes

### \`internal/api/window.go\` (new)

- \`APIWindowDays = 89\` — the empirically-confirmed boundary
- \`ClampToWindow(start, end)\` — checks the requested range; clamps \`--start\` forward to \`today − 89 days\` if older, returning a user-visible notice. Hard-errors if \`--end\` is also older than the window.
- \`LoadRange(client, start, end)\` — runs \`ClampToWindow\` then iterates fetching each date. Per-day \`ErrOutOfWindow\` (400) responses are skipped and aggregated into a single summary notice; other HTTP errors still abort.

### \`internal/api/client.go\`

- New sentinel \`ErrOutOfWindow\`. \`FetchDay\` now wraps it on HTTP 400 so callers can \`errors.Is\` to differentiate retention-window 400s from genuine errors.

### \`cmd/root.go\` and \`internal/tui/model.go\`

- The two near-duplicate fetch-loop wrappers (\`loadLogs\`, \`fetchLogs\`) are deleted in favour of \`api.LoadRange\`.
- Pipeline mode prints notices to stderr (\`note: ...\`).
- The TUI threads notices through \`dataMsg\` and renders them in the status bar via \`statusMsg\`.

## Verification

\`go build ./...\` and \`go vet ./...\` pass.

\`\`\`bash
go build -o wwlog .

# Was: error at 2026-02-01. Now: clamps and runs.
./wwlog --start 2026-02-01 --end 2026-05-05 --report
# stderr: note: --start clamped to 2026-02-05 (WW retains ~90 days)
# stdout: full 90-day report

# Both ends out of window — hard error before any API call.
./wwlog --start 2024-01-01 --end 2024-06-01 --report
# Error: end date 2024-06-01 is older than WW's ~90-day retention window
#        (earliest queryable: 2026-02-05)

# In-window query: unchanged behaviour, no notices.
./wwlog --start 2026-04-29 --end 2026-05-05 --report
\`\`\`

Date-handling note: ClampToWindow uses the user's local calendar date (parsed back from \`time.Now().Format\`) rather than UTC, so the clamp boundary matches WW's account-local boundary even if the user is east of UTC.

Closes #38, Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)