### PR TITLE
fix: dialog bg fill + dim bar marker + drop heatmap dot separator

### DIFF
--- a/internal/tui/dialog.go
+++ b/internal/tui/dialog.go
@@ -20,12 +20,28 @@ func dialogContentWidth(termWidth int) int {
 // with a teal title at the top and a muted hint line at the bottom. The
 // result is intended to be composited over the main TUI by overlayDialog.
 func renderDialog(title, body, hint string) string {
+	titleR := styleDialogTitle.Render(title)
+	hintR := styleDialogHint.Render(hint)
+
+	// Force every row to the widest row's width with colorPanel background.
+	// Without this, JoinVertical pads shorter rows with plain spaces (no
+	// background), so terminal default bg shows through wherever a row is
+	// narrower than the body — including the blank separator rows.
+	width := lipgloss.Width(body)
+	if w := lipgloss.Width(titleR); w > width {
+		width = w
+	}
+	if w := lipgloss.Width(hintR); w > width {
+		width = w
+	}
+	pad := lipgloss.NewStyle().Background(colorPanel).Width(width)
+
 	inner := lipgloss.JoinVertical(lipgloss.Left,
-		styleDialogTitle.Render(title),
-		"",
-		body,
-		"",
-		styleDialogHint.Render(hint),
+		pad.Render(titleR),
+		pad.Render(""),
+		pad.Render(body),
+		pad.Render(""),
+		pad.Render(hintR),
 	)
 	return styleDialogBox.Render(inner)
 }

--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -344,10 +344,10 @@ func renderHeatmap(logs []*api.DayLog, vw int) string {
 		styleFoodPortion.Render(string(hdr)))
 
 	// Day rows Mon→Sun, only Mon/Wed/Fri labelled (GitHub convention).
-	// Inter-cell gap rendered as a middle dot in the no-data colour so the
-	// boundary between adjacent cells stays visible even when neighbours
-	// share a colour (e.g. two no-data cells in a row).
-	gapStr := lipgloss.NewStyle().Foreground(colorLine).Render(strings.Repeat("·", gap))
+	// Plain-space gap between weeks — the half-height ▄ cells already
+	// provide a visible vertical gap (empty top half of each row), so a
+	// styled · separator on top read as visual noise.
+	gapStr := strings.Repeat(" ", gap)
 	dayNames := [7]string{"Mon", "", "Wed", "", "Fri", "", ""}
 	for row, name := range dayNames {
 		label := fmt.Sprintf("%-*s", dayLabelW, name)

--- a/internal/tui/nutrition.go
+++ b/internal/tui/nutrition.go
@@ -475,7 +475,7 @@ func makeBar(value, max float64, width int) string {
 	}
 
 	fillStyle := lipgloss.NewStyle().Foreground(barColor)
-	markerStyle := lipgloss.NewStyle().Foreground(colorMuted)
+	markerStyle := lipgloss.NewStyle().Foreground(colorLine)
 
 	var b strings.Builder
 	if full > 0 {


### PR DESCRIPTION
## Summary

Three small fixes to recent visual work, all in the TUI.

### Dialog interior background fills cleanly

\`renderDialog\` (\`internal/tui/dialog.go\`) was using \`lipgloss.JoinVertical\` to stack the title, body, and hint rows. \`JoinVertical\` pads shorter rows with **plain** spaces (no background), so wherever a row was narrower than the body, terminal default bg showed through — most visibly on the loading splash where the short title (\`Loading\`) and hint (\`ctrl+c to quit\`) leaked through to the TUI content beneath the dialog.

Fix: compute the widest row, then wrap each row in a \`Background(colorPanel).Width(w)\` style before joining. Every line is padded with bg-coloured spaces, so the dialog interior fills cleanly.

### Dim bar marker

The \`│\` right-edge marker on inline bars (\`makeBar\`) drops from \`colorMuted\` (\`#a8b6c0\`) to \`colorLine\` (\`#2b3742\`) — the same shade as the heatmap's no-data cells. Reads as a quiet boundary line rather than a near-foreground-bright stroke.

### Drop heatmap dot separator between weeks

\`renderHeatmap\` was inserting a \`colorLine\`-styled \`·\` between every pair of week columns. With cells now being \`▄\` (LOWER HALF BLOCK), every cell already has a visible empty-top-half row above it — so the dots were noise on top of an already-visible gap. Replaced with a plain space.

## Verification

\`go build ./...\` and \`go vet ./...\` pass.

\`\`\`bash
go build -o wwlog .
./wwlog                                       # splash dialog: bg should fill cleanly behind title/hint
./wwlog --start 2026-04-29 --end 2026-05-05   # heatmap: no dots between weeks; bars: dim │ marker
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)