### PR TITLE
docs: document the WW API's ~90-day retention window

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ wwlog --start 2026-04-20 --end 2026-04-26 --export json --output ~/Downloads/
 wwlog --logout
 ```
 
+## Data window
+
+The WW `my-day` endpoint enforces a hard ~90-day backwards retention window — any date more
+than 89 days before today returns HTTP 400, regardless of how long you've held your WW account.
+This is a server-side policy, not a wwlog limitation.
+
+If `--start` is older than the window, wwlog clamps it forward and prints a one-line notice:
+
+```bash
+$ wwlog --start 2024-01-01 --end 2026-05-05 --report
+note: --start clamped to 2026-02-05 (WW retains ~90 days)
+```
+
+If `--end` is also older than the window, wwlog errors out before making any API calls. There's
+no workaround — long-running history exports aren't possible with this API. Plan ahead if you
+want to keep more than ~3 months of records: pull `--export json` regularly and archive the files.
+
 ## JSON pipeline examples
 
 The `--json` flag outputs a JSON array of day logs. Each element contains the date, meals

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&flagStart, "start", "s", "", "Start date (YYYY-MM-DD, default: last 7 days)")
+	rootCmd.Flags().StringVarP(&flagStart, "start", "s", "", "Start date (YYYY-MM-DD, default: last 7 days; WW retains ~90 days)")
 	rootCmd.Flags().StringVarP(&flagEnd, "end", "e", "", "End date (YYYY-MM-DD, default: today)")
 	rootCmd.Flags().BoolVar(&flagJSON, "json", false, "Emit log as JSON to stdout")
 	rootCmd.Flags().BoolVarP(&flagReport, "report", "r", false, "Emit insights report to stdout")


### PR DESCRIPTION
## Summary

Closes #40.

The WW \`my-day\` endpoint enforces a hard 89-day backwards retention window, returning HTTP 400 for any older date regardless of account age. PRs #38/#39 made wwlog handle this gracefully (clamp + skip-and-warn). This PR makes the limit discoverable so users don't bounce off it accidentally.

## Changes

### \`--help\` flag description

\`\`\`
-s, --start string    Start date (YYYY-MM-DD, default: last 7 days; WW retains ~90 days)
\`\`\`

### \`README.md\`: new "Data window" section

Explains the server-side policy, shows the clamp notice and hard-error behaviour, and gives the workaround (regular \`--export json\` archiving) for users who want long-term history.

## Verification

- \`go build ./...\` passes
- \`./wwlog --help\` confirms the new \`--start\` description
- \`markdownlint README.md\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of [Alister](https://github.com/ali5ter)