### PR TITLE
feat: lead with Insights tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ viewing insights, plus a pipeline mode for scripting and file export.
   subscription changes, API windows, and app discontinuations
 - **Offline mode** — browse, report, and export from your local archive with no
   network calls required
-- **Log tab** — day-by-day food log with a points bar, meal breakdown, and per-entry kcal;
-  filter by date and sort entries by points or calories
-- **Nutrition tab** — nutrient bars vs. recommended daily values, per-day averages,
-  and trend charts for calories, protein, carbs, and fat across the selected range
 - **Insights tab** — a calendar heatmap of daily points budget, range summary,
   points by meal, macro distribution, top foods by points, and a zero-point food log
+- **Nutrition tab** — nutrient bars vs. recommended daily values, per-day averages,
+  and trend charts for calories, protein, carbs, and fat across the selected range
+- **Log tab** — day-by-day food log with a points bar, meal breakdown, and per-entry kcal;
+  filter by date and sort entries by points or calories
 - **Pipeline mode** — `--json`, `--report`, and `--export` flags for scripting and file output
 - **No DevTools required** — one `--login` step stores credentials in your system keychain
 

--- a/examples/wwlog_demo.tape
+++ b/examples/wwlog_demo.tape
@@ -33,7 +33,44 @@ Enter
 # Loading 30 days from the API
 Sleep 4s
 
+# ── Insights tab (default on launch) ────────────────────────────
+Sleep 1300ms
+PageDown
+Sleep 1800ms
+PageUp
+Sleep 1300ms
+
+# ── Nutrition tab ─────────────────────────────────────────────
+Tab
+Sleep 800ms
+Down
+Sleep 500ms
+Down
+Sleep 500ms
+Down
+Sleep 800ms
+
+# Focus the detail pane and scroll past the nutrient bars into the
+# Carbs/Fat trend charts below the fold
+Right
+Sleep 700ms
+Down
+Sleep 300ms
+Down
+Sleep 300ms
+Down
+Sleep 300ms
+Down
+Sleep 300ms
+Down
+Sleep 300ms
+Down
+Sleep 900ms
+Left
+Sleep 500ms
+
 # ── Log tab ──────────────────────────────────────────────────
+Tab
 Sleep 800ms
 Down
 Sleep 500ms
@@ -82,43 +119,6 @@ Backspace
 Sleep 100ms
 Enter
 Sleep 500ms
-
-# ── Nutrition tab ─────────────────────────────────────────────
-Tab
-Sleep 800ms
-Down
-Sleep 500ms
-Down
-Sleep 500ms
-Down
-Sleep 800ms
-
-# Focus the detail pane and scroll past the nutrient bars into the
-# Carbs/Fat trend charts below the fold
-Right
-Sleep 700ms
-Down
-Sleep 300ms
-Down
-Sleep 300ms
-Down
-Sleep 300ms
-Down
-Sleep 300ms
-Down
-Sleep 300ms
-Down
-Sleep 900ms
-Left
-Sleep 500ms
-
-# ── Insights tab ─────────────────────────────────────────────
-Tab
-Sleep 1300ms
-PageDown
-Sleep 1800ms
-PageUp
-Sleep 1300ms
 
 # ── Export dialog ─────────────────────────────────────────────
 Type "e"

--- a/internal/tui/assets/exit_messages.txt
+++ b/internal/tui/assets/exit_messages.txt
@@ -5,7 +5,6 @@
 You look amazing!
 Progress, not perfection.
 Small steps add up to big change.
-Keep going, you've got this!
 One day at a time.
 Your consistency is paying off.
 Nourishing choices, well done.

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -46,9 +46,9 @@ func TestHelpKeyMapFullHelp(t *testing.T) {
 		wantHasSort   bool
 		wantHasFocus  bool
 	}{
-		{"log", tabLog, true, true, true},
-		{"nutrition", tabNutrition, true, false, true},
 		{"insights", tabInsights, false, false, false},
+		{"nutrition", tabNutrition, true, false, true},
+		{"log", tabLog, true, true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestHelpKeyMapFullHelp(t *testing.T) {
 // click hit-test drifting apart — the same class of bug v1.14.0 fixed in
 // dateRowAtPoint (see panes.go).
 func TestHeaderTabsOffsetMatchesTabAtPoint(t *testing.T) {
-	m := Model{width: 100, activeTab: tabLog}
+	m := Model{width: 100, activeTab: tabInsights}
 	offset := headerTabsOffset()
 
 	if _, ok := m.tabAtPoint(offset-1, 0); ok {
@@ -93,11 +93,12 @@ func newTestModel() Model {
 	logs := []*api.DayLog{manyEntriesLog("2026-06-10")}
 	loc := newLocale("com", "")
 	return Model{
-		screen:   screenLog,
-		width:    100,
-		height:   30,
-		logs:     logs,
-		logModel: newLogModel(logs, 100, 24, loc),
+		screen:    screenLog,
+		activeTab: tabLog,
+		width:     100,
+		height:    30,
+		logs:      logs,
+		logModel:  newLogModel(logs, 100, 24, loc),
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -34,12 +34,12 @@ const (
 type tab int
 
 const (
-	tabLog tab = iota
+	tabInsights tab = iota
 	tabNutrition
-	tabInsights
+	tabLog
 )
 
-var tabNames = []string{"Log", "Nutrition", "Insights"}
+var tabNames = []string{"Insights", "Nutrition", "Log"}
 
 type dataMsg struct {
 	logs    []*api.DayLog
@@ -102,8 +102,10 @@ func Run(authObj *auth.Auth, tld, weightUnit string, ds api.DayStore, targets *c
 	s.Style = lipgloss.NewStyle().Foreground(colorTeal)
 
 	m := Model{
-		spinner:     s,
-		screen:      screenSplash,
+		spinner: s,
+		screen:  screenSplash,
+		// activeTab is left at its zero value, tabInsights — the TUI leads
+		// with the Insights tab on launch.
 		splashModel: newSplashModel(authObj, version, preStart, preEnd),
 		authObj:     authObj,
 		tld:         tld,


### PR DESCRIPTION
## Summary
- Reorder the tab strip and startup tab to Insights / Nutrition / Log, matching the actual value case — Insights and Nutrition surface the analytics people open wwlog for, while Log is the reference detail view
- The tab enum's zero value now drives the default, so the TUI opens on Insights without any special-casing
- Trim a redundant line from the exit-message pool

Closes #73

🤖 Generated with [claude-workflow-skills:promote](https://github.com/ali5ter/claude-workflow-skills) on behalf of [Alister](https://github.com/ali5ter)