### PR TITLE
feat: responsive two-column Insights layout

### DIFF
--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -19,6 +19,9 @@ type insightsModel struct {
 	width       int
 	height      int
 	initialized bool
+	// twoCol tracks the last layout tier render() used, so resize can detect
+	// a crossing and reset scroll — see resize.
+	twoCol bool
 }
 
 func newInsightsModel(logs []*api.DayLog, width, height int) insightsModel {
@@ -31,6 +34,7 @@ func newInsightsModel(logs []*api.DayLog, width, height int) insightsModel {
 		height:      height,
 		initialized: true,
 	}
+	_, m.twoCol = insightsColumns(insightsViewWidth(m.width))
 	m.viewport.SetContent(m.render())
 	return m
 }
@@ -65,11 +69,31 @@ func (m *insightsModel) resize(width, height int) {
 	if !m.initialized {
 		return
 	}
+	prevTwoCol := m.twoCol
 	m.width = width
 	m.height = height
 	m.viewport.SetWidth(width - 2)
 	m.viewport.SetHeight(height)
+	_, m.twoCol = insightsColumns(insightsViewWidth(m.width))
 	m.viewport.SetContent(m.render())
+	// Crossing the two-column breakpoint roughly halves (or doubles) the
+	// document's height. Without this, a user scrolled partway down would
+	// get silently snapped to the bottom by the viewport's own offset clamp.
+	if m.twoCol != prevTwoCol {
+		m.viewport.GotoTop()
+	}
+}
+
+// insightsViewWidth converts the tab's total width to the content width its
+// sections render at — matches the -4 the viewport (-2) and its Padding(0,1)
+// (-2) already cost, floored so a very narrow terminal can't drive section
+// widths negative.
+func insightsViewWidth(width int) int {
+	vw := width - 4
+	if vw < 40 {
+		vw = 40
+	}
+	return vw
 }
 
 func (m *insightsModel) render() string {
@@ -77,22 +101,15 @@ func (m *insightsModel) render() string {
 		return styleFoodPortion.Render("No data available.")
 	}
 
-	vw := m.width - 4
-	if vw < 40 {
-		vw = 40
-	}
-	barWidth := 22
-	if barWidth > vw-30 {
-		barWidth = vw - 30
-	}
-	if barWidth < 8 {
-		barWidth = 8
-	}
-	sep := styleDim.Render(strings.Repeat("─", vw-2))
+	vw := insightsViewWidth(m.width)
+	colW, twoCol := insightsColumns(vw)
 
 	summary := api.ComputeRangeSummary(m.logs)
 	meals := api.MealStats(m.logs)
 	macros := api.AvgMacroBreakdown(m.logs)
+	micro, hasMicro := computeMicroAverages(m.logs)
+	zpFoods := zeroPointFoods(m.logs)
+
 	// TopFoods returns all foods sorted by total points; filter zeros so only
 	// point-costing foods appear here (zero-point foods get their own section).
 	var foods []api.FoodStat
@@ -106,46 +123,110 @@ func (m *insightsModel) render() string {
 		}
 	}
 
+	// The heatmap doesn't stretch to fill vw (see renderHeatmap) — measure
+	// its actual rendered width to decide whether Range Summary fits beside
+	// it on the same row, rather than assuming a fixed natural width.
+	rawHeatmap := renderHeatmap(m.logs, vw)
+	hmW := blockWidth(rawHeatmap)
+	wideRow := twoCol && vw-hmW-insightsGutter >= insightsMinColWidth
+
+	headingWidth := vw
+	if wideRow {
+		headingWidth = hmW
+	}
+	heatmap := sectionHeading("Points Budget  (day by day)", "Points Budget", headingWidth) +
+		"\n\n" + rawHeatmap
+
+	var rows []string
+	switch {
+	case wideRow:
+		rightW := vw - hmW - insightsGutter
+		rows = append(rows,
+			joinColumns(heatmap, hmW, rangeSummarySection(summary, rightW), rightW),
+			joinColumns(mealsSection(meals, colW), colW, macrosSection(macros, colW), colW),
+			joinColumns(microsSection(micro, hasMicro, colW), colW, topFoodsSection(foods, colW), colW),
+			zeroPointSection(zpFoods, vw),
+		)
+	case twoCol:
+		rows = append(rows,
+			heatmap,
+			joinColumns(rangeSummarySection(summary, colW), colW, mealsSection(meals, colW), colW),
+			joinColumns(macrosSection(macros, colW), colW, microsSection(micro, hasMicro, colW), colW),
+			joinColumns(topFoodsSection(foods, colW), colW, zeroPointSection(zpFoods, colW), colW),
+		)
+	default:
+		rows = append(rows,
+			heatmap,
+			rangeSummarySection(summary, vw),
+			mealsSection(meals, vw),
+			macrosSection(macros, vw),
+			microsSection(micro, hasMicro, vw),
+			topFoodsSection(foods, vw),
+			zeroPointSection(zpFoods, vw),
+		)
+	}
+
+	var out []string
+	for _, r := range rows {
+		if strings.TrimSpace(r) != "" {
+			out = append(out, r)
+		}
+	}
+	return strings.Join(out, "\n\n")
+}
+
+// rangeSummarySection renders the days/items line plus the Points, Calories,
+// and Activity bars/lines, sized to width w.
+func rangeSummarySection(s api.RangeSummary, w int) string {
+	pointsRow := func(bw int) string {
+		return fmt.Sprintf("  %s  %s  %s",
+			lipgloss.NewStyle().Width(10).Render(styleDetailLabel.Render("Points")),
+			makeBar(s.AvgDailyPts, s.AvgDailyTarget, bw, false),
+			styleDetailValue.Render(fmt.Sprintf("avg %.0fpt / %.0fpt target", s.AvgDailyPts, s.AvgDailyTarget)),
+		)
+	}
+	calsRow := func(bw int) string {
+		return fmt.Sprintf("  %s  %s  %s",
+			lipgloss.NewStyle().Width(10).Render(styleDetailLabel.Render("Calories")),
+			makeBar(s.AvgDailyCals, 2000, bw, false),
+			styleDetailValue.Render(fmt.Sprintf("avg %.0f kcal / day", s.AvgDailyCals)),
+		)
+	}
+	var rows []func(int) string
+	if s.AvgDailyTarget > 0 {
+		rows = append(rows, pointsRow)
+	}
+	if s.AvgDailyCals > 0 {
+		rows = append(rows, calsRow)
+	}
+	barWidth := barWidthForRows(w, rows...)
+
 	var b strings.Builder
+	b.WriteString(sectionHeading("Range Summary", "Range Summary", w))
+	b.WriteString("\n\n")
 
-	// ── Points Heatmap ─────────────────────────────────────────────
-	fmt.Fprintf(&b, "%s\n%s\n\n", styleMealHeading.Render("Points Budget  (day by day)"), sep)
-	fmt.Fprintf(&b, "%s\n\n", renderHeatmap(m.logs, vw))
-
-	// ── Range Summary ──────────────────────────────────────────────
-	fmt.Fprintf(&b, "%s\n%s\n\n", styleMealHeading.Render("Range Summary"), sep)
-
-	daysStr := fmt.Sprintf("%d days  ·  %d food items logged", summary.Days, summary.TotalItems)
+	daysStr := fmt.Sprintf("%d days  ·  %d food items logged", s.Days, s.TotalItems)
 	fmt.Fprintf(&b, "  %s\n\n", styleDetailValue.Render(daysStr))
 
-	if summary.AvgDailyTarget > 0 {
-		ptsBar := makeBar(summary.AvgDailyPts, summary.AvgDailyTarget, barWidth, false)
-		fmt.Fprintf(&b, "  %s  %s  %s\n",
-			lipgloss.NewStyle().Width(10).Render(styleDetailLabel.Render("Points")),
-			ptsBar,
-			styleDetailValue.Render(fmt.Sprintf("avg %.0fpt / %.0fpt target", summary.AvgDailyPts, summary.AvgDailyTarget)),
-		)
-		budgetStr := fmt.Sprintf("%d days on/under budget  ·  %d days over", summary.DaysUnderBudget, summary.DaysOverBudget)
+	if s.AvgDailyTarget > 0 {
+		fmt.Fprintf(&b, "%s\n", pointsRow(barWidth))
+		budgetStr := fmt.Sprintf("%d days on/under budget  ·  %d days over", s.DaysUnderBudget, s.DaysOverBudget)
 		fmt.Fprintf(&b, "  %s\n", styleFoodPortion.Render(budgetStr))
 	}
-	if summary.AvgDailyCals > 0 {
-		calBar := makeBar(summary.AvgDailyCals, 2000, barWidth, false)
-		fmt.Fprintf(&b, "  %s  %s  %s\n",
-			lipgloss.NewStyle().Width(10).Render(styleDetailLabel.Render("Calories")),
-			calBar,
-			styleDetailValue.Render(fmt.Sprintf("avg %.0f kcal / day", summary.AvgDailyCals)),
-		)
+	if s.AvgDailyCals > 0 {
+		fmt.Fprintf(&b, "%s\n", calsRow(barWidth))
 		fmt.Fprintf(&b, "  %s\n", styleFoodPortion.Render("bar shows % of 2000 kcal reference"))
 	}
-	activityStr := fmt.Sprintf("%.0fpt earned across %d days", summary.TotalActivityEarned, summary.DaysWithActivity)
+	activityStr := fmt.Sprintf("%.0fpt earned across %d days", s.TotalActivityEarned, s.DaysWithActivity)
 	fmt.Fprintf(&b, "  %s  %s\n",
 		lipgloss.NewStyle().Width(10).Render(styleDetailLabel.Render("Activity")),
 		styleDetailValue.Render(activityStr),
 	)
+	return strings.TrimRight(b.String(), "\n")
+}
 
-	// ── Points by Meal ─────────────────────────────────────────────
-	fmt.Fprintf(&b, "\n%s\n%s\n\n", styleMealHeading.Render("Points by Meal  (average per day)"), sep)
-
+// mealsSection renders one bar row per meal period, sized to width w.
+func mealsSection(meals []api.MealStat, w int) string {
 	var maxMealPts float64
 	for _, ms := range meals {
 		if ms.AvgPts > maxMealPts {
@@ -155,31 +236,89 @@ func (m *insightsModel) render() string {
 	if maxMealPts == 0 {
 		maxMealPts = 1
 	}
-	for _, ms := range meals {
-		bar := makeBar(ms.AvgPts, maxMealPts, barWidth, false)
-		label := lipgloss.NewStyle().Width(12).Render(styleDetailLabel.Render(ms.Symbol + "  " + ms.Name))
-		val := styleDetailValue.Render(fmt.Sprintf("%.1fpt", ms.AvgPts))
-		cal := styleFoodPortion.Render(fmt.Sprintf("  %.0f kcal", ms.AvgCals))
-		fmt.Fprintf(&b, "  %s  %s  %s%s\n", label, bar, val, cal)
-	}
 
-	// ── Macro Distribution ─────────────────────────────────────────
-	fmt.Fprintf(&b, "\n%s\n%s\n\n", styleMealHeading.Render("Macro Distribution  (average daily, % of calories)"), sep)
+	mealRow := func(ms api.MealStat) func(int) string {
+		return func(bw int) string {
+			bar := makeBar(ms.AvgPts, maxMealPts, bw, false)
+			label := lipgloss.NewStyle().Width(12).Render(styleDetailLabel.Render(ms.Symbol + "  " + ms.Name))
+			val := styleDetailValue.Render(fmt.Sprintf("%.1fpt", ms.AvgPts))
+			cal := styleFoodPortion.Render(fmt.Sprintf("  %.0f kcal", ms.AvgCals))
+			return fmt.Sprintf("  %s  %s  %s%s", label, bar, val, cal)
+		}
+	}
+	rows := make([]func(int) string, len(meals))
+	for i, ms := range meals {
+		rows[i] = mealRow(ms)
+	}
+	barWidth := barWidthForRows(w, rows...)
+
+	var b strings.Builder
+	b.WriteString(sectionHeading("Points by Meal  (average per day)", "Points by Meal", w))
+	b.WriteString("\n\n")
+	for _, row := range rows {
+		fmt.Fprintf(&b, "%s\n", row(barWidth))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// macrosSection renders the Protein/Carbs/Fat/Alcohol bars, sized to width w.
+func macrosSection(macros api.MacroBreakdown, w int) string {
+	var b strings.Builder
+	b.WriteString(sectionHeading("Macro Distribution  (average daily, % of calories)", "Macro Distribution", w))
+	b.WriteString("\n\n")
 
 	if macros.ProteinG+macros.CarbsG+macros.FatG == 0 {
 		fmt.Fprintf(&b, "  %s\n", styleFoodPortion.Render("No nutrition data available."))
-	} else {
-		writeMacroBar(&b, "Protein", macros.ProteinPct, macros.ProteinG, "g", barWidth)
-		writeMacroBar(&b, "Carbs", macros.CarbsPct, macros.CarbsG, "g", barWidth)
-		writeMacroBar(&b, "Fat", macros.FatPct, macros.FatG, "g", barWidth)
-		if macros.AlcoholG > 0 {
-			writeMacroBar(&b, "Alcohol", macros.AlcoholPct, macros.AlcoholG, "g", barWidth)
-		}
-		fmt.Fprintf(&b, "\n  %s\n", styleFoodPortion.Render("Recommended: ~20% protein  ·  ~50% carbs  ·  ~30% fat"))
+		return strings.TrimRight(b.String(), "\n")
 	}
 
-	// ── Micronutrients ─────────────────────────────────────────────
-	nutrition := api.ComputeAllNutrition(m.logs)
+	rows := []func(int) string{
+		macroBarRow("Protein", macros.ProteinPct, macros.ProteinG, "g"),
+		macroBarRow("Carbs", macros.CarbsPct, macros.CarbsG, "g"),
+		macroBarRow("Fat", macros.FatPct, macros.FatG, "g"),
+	}
+	if macros.AlcoholG > 0 {
+		rows = append(rows, macroBarRow("Alcohol", macros.AlcoholPct, macros.AlcoholG, "g"))
+	}
+	barWidth := barWidthForRows(w, rows...)
+	for _, row := range rows {
+		fmt.Fprintf(&b, "%s\n", row(barWidth))
+	}
+
+	footnote := "Recommended: ~20% protein  ·  ~50% carbs  ·  ~30% fat"
+	if lipgloss.Width(footnote) > w {
+		footnote = "Rec: 20% protein · 50% carbs · 30% fat"
+	}
+	fmt.Fprintf(&b, "\n  %s\n", styleFoodPortion.Render(footnote))
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// macroBarRow returns a row builder for one macronutrient's bar — deferred
+// like this so barWidthForRows can measure the row's non-bar width (which
+// varies with the gram/percentage values) before a shared bar width for the
+// whole section is settled on.
+func macroBarRow(label string, pct, grams float64, unit string) func(int) string {
+	return func(bw int) string {
+		bar := makeBar(pct, 100, bw, false)
+		labelCol := lipgloss.NewStyle().Width(11).Render(styleDetailLabel.Render(label))
+		pctCol := lipgloss.NewStyle().Width(6).Render(styleDetailValue.Render(fmt.Sprintf("%.0f%%", pct)))
+		gramCol := styleFoodPortion.Render(fmt.Sprintf("%.0f%s avg", grams, unit))
+		return fmt.Sprintf("  %s%s  %s  %s", labelCol, pctCol, bar, gramCol)
+	}
+}
+
+// microAverages holds the range-wide daily averages microsSection bars against
+// their reference values.
+type microAverages struct {
+	fiber, sodium, addedSugar, saturatedFat float64
+}
+
+// computeMicroAverages averages fiber/sodium/added-sugar/saturated-fat across
+// days that have any logged nutrition data. The bool return is false when no
+// day in the range has nutrition data, so microsSection can omit itself
+// entirely rather than showing an all-zero section.
+func computeMicroAverages(logs []*api.DayLog) (microAverages, bool) {
+	nutrition := api.ComputeAllNutrition(logs)
 	var fiberSum, sodiumSum, addedSugarSum, saturatedFatSum float64
 	daysWithData := 0
 	for _, dn := range nutrition {
@@ -191,68 +330,109 @@ func (m *insightsModel) render() string {
 			daysWithData++
 		}
 	}
-	if daysWithData > 0 {
-		n := float64(daysWithData)
-		fmt.Fprintf(&b, "\n%s\n%s\n\n", styleMealHeading.Render("Daily Averages  (fiber · sodium · added sugar · saturated fat)"), sep)
-		writeMicroBar := func(label, unit string, avg, ref float64) {
-			bar := makeBar(avg, ref, barWidth, false)
-			labelCol := lipgloss.NewStyle().Width(13).Render(styleDetailLabel.Render(label))
-			valCol := lipgloss.NewStyle().Width(12).Render(styleDetailValue.Render(fmt.Sprintf("%s %s", formatNutriValue(avg), unit)))
-			refStr := styleFoodPortion.Render(fmt.Sprintf("ref %s", formatNutriValue(ref)))
-			fmt.Fprintf(&b, "  %s%s%s  %s\n", labelCol, valCol, bar, refStr)
-		}
-		writeMicroBar("Fiber", "g", fiberSum/n, rdv.Fiber)
-		writeMicroBar("Sodium", "mg", sodiumSum/n, rdv.Sodium)
-		writeMicroBar("Added Sugar", "g", addedSugarSum/n, rdv.AddedSugar)
-		writeMicroBar("Sat Fat", "g", saturatedFatSum/n, rdv.SaturatedFat)
+	if daysWithData == 0 {
+		return microAverages{}, false
 	}
+	n := float64(daysWithData)
+	return microAverages{
+		fiber:        fiberSum / n,
+		sodium:       sodiumSum / n,
+		addedSugar:   addedSugarSum / n,
+		saturatedFat: saturatedFatSum / n,
+	}, true
+}
 
-	// ── Top Foods by Points ─────────────────────────────────────────
-	fmt.Fprintf(&b, "\n%s\n%s\n\n", styleMealHeading.Render("Top Foods by Points"), sep)
+// microsSection renders the fiber/sodium/added-sugar/saturated-fat bars,
+// sized to width w. Returns "" when has is false, so callers can drop it
+// from the layout the same way an empty food table is dropped.
+func microsSection(avg microAverages, has bool, w int) string {
+	if !has {
+		return ""
+	}
+	rows := []func(int) string{
+		microBarRow("Fiber", "g", avg.fiber, rdv.Fiber),
+		microBarRow("Sodium", "mg", avg.sodium, rdv.Sodium),
+		microBarRow("Added Sugar", "g", avg.addedSugar, rdv.AddedSugar),
+		microBarRow("Sat Fat", "g", avg.saturatedFat, rdv.SaturatedFat),
+	}
+	barWidth := barWidthForRows(w, rows...)
+
+	var b strings.Builder
+	heading := "Daily Averages  (fiber · sodium · added sugar · saturated fat)"
+	b.WriteString(sectionHeading(heading, "Daily Averages", w))
+	b.WriteString("\n\n")
+	for _, row := range rows {
+		fmt.Fprintf(&b, "%s\n", row(barWidth))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// microBarRow returns a row builder for one micronutrient's bar — see
+// macroBarRow for why this is deferred rather than returning a string.
+func microBarRow(label, unit string, avg, ref float64) func(int) string {
+	return func(bw int) string {
+		bar := makeBar(avg, ref, bw, false)
+		labelCol := lipgloss.NewStyle().Width(13).Render(styleDetailLabel.Render(label))
+		valCol := lipgloss.NewStyle().Width(12).Render(styleDetailValue.Render(fmt.Sprintf("%s %s", formatNutriValue(avg), unit)))
+		refStr := styleFoodPortion.Render(fmt.Sprintf("ref %s", formatNutriValue(ref)))
+		return fmt.Sprintf("  %s%s%s  %s", labelCol, valCol, bar, refStr)
+	}
+}
+
+// topFoodsSection renders the Top Foods by Points leaderboard, sized to
+// width w — see topFoodsLayout for how its columns shed as w shrinks.
+func topFoodsSection(foods []api.FoodStat, w int) string {
+	var b strings.Builder
+	b.WriteString(sectionHeading("Top Foods by Points", "Top Foods", w))
+	b.WriteString("\n\n")
 
 	if len(foods) == 0 {
 		fmt.Fprintf(&b, "  %s\n", styleFoodPortion.Render("No food data available."))
-	} else {
-		nameW := 32
-		for _, fs := range foods {
-			name := truncate(fs.Name, nameW)
-			countStr := styleFoodPortion.Render(fmt.Sprintf("%d×", fs.Count))
-			totalPts := styleDetailValue.Render(fmt.Sprintf("%.0fpt total", fs.TotalPts))
-			avgPts := styleFoodPortion.Render(fmt.Sprintf("%.0fpt avg", fs.AvgPts))
-			avgCals := ""
-			if fs.AvgCals > 0 {
-				avgCals = styleFoodPortion.Render(fmt.Sprintf("  %.0f kcal avg", fs.AvgCals))
-			}
-			nameCol := lipgloss.NewStyle().Width(nameW + 2).Render(styleFoodItem.Render(name))
-			countCol := lipgloss.NewStyle().Width(5).Render(countStr)
-			totalCol := lipgloss.NewStyle().Width(14).Render(totalPts)
-			avgCol := lipgloss.NewStyle().Width(12).Render(avgPts)
-			fmt.Fprintf(&b, "  %s%s%s%s%s\n", nameCol, countCol, totalCol, avgCol, avgCals)
-		}
+		return strings.TrimRight(b.String(), "\n")
 	}
 
-	// ── All Foods (zero-point) ───────────────────────────────────────
-	zpFoods := zeroPointFoods(m.logs)
-	if len(zpFoods) > 0 {
-		fmt.Fprintf(&b, "\n%s\n%s\n\n", styleMealHeading.Render("Zero-Point Foods Logged"), sep)
-		for _, fs := range zpFoods {
-			name := truncate(fs.Name, 32)
-			countStr := styleFoodPortion.Render(fmt.Sprintf("%d×", fs.Count))
-			calsStr := styleFoodPortion.Render(fmt.Sprintf("  %.0f kcal avg", fs.AvgCals))
-			nameCol := lipgloss.NewStyle().Width(34).Render(styleFoodItem.Render(name))
-			fmt.Fprintf(&b, "  %s%s%s\n", nameCol, countStr, calsStr)
+	layout := topFoodsLayout(w)
+	for _, fs := range foods {
+		name := truncate(fs.Name, layout.nameW-2)
+		nameCol := lipgloss.NewStyle().Width(layout.nameW).Render(styleFoodItem.Render(name))
+		countCol := lipgloss.NewStyle().Width(foodCountW).Render(styleFoodPortion.Render(fmt.Sprintf("%d×", fs.Count)))
+		totalCol := lipgloss.NewStyle().Width(foodTotalPtsW).Render(styleDetailValue.Render(fmt.Sprintf("%.0fpt total", fs.TotalPts)))
+		fmt.Fprintf(&b, "  %s%s%s", nameCol, countCol, totalCol)
+		if layout.showAvgPts {
+			avgCol := lipgloss.NewStyle().Width(foodAvgPtsW).Render(styleFoodPortion.Render(fmt.Sprintf("%.0fpt avg", fs.AvgPts)))
+			fmt.Fprint(&b, avgCol)
 		}
+		if layout.showKcal && fs.AvgCals > 0 {
+			fmt.Fprint(&b, styleFoodPortion.Render(fmt.Sprintf("  %.0f kcal avg", fs.AvgCals)))
+		}
+		fmt.Fprintln(&b)
 	}
-
-	return b.String()
+	return strings.TrimRight(b.String(), "\n")
 }
 
-func writeMacroBar(b *strings.Builder, label string, pct, grams float64, unit string, barWidth int) {
-	bar := makeBar(pct, 100, barWidth, false)
-	labelCol := lipgloss.NewStyle().Width(11).Render(styleDetailLabel.Render(label))
-	pctCol := lipgloss.NewStyle().Width(6).Render(styleDetailValue.Render(fmt.Sprintf("%.0f%%", pct)))
-	gramCol := styleFoodPortion.Render(fmt.Sprintf("%.0f%s avg", grams, unit))
-	fmt.Fprintf(b, "  %s%s  %s  %s\n", labelCol, pctCol, bar, gramCol)
+// zeroPointSection renders the Zero-Point Foods table, sized to width w.
+// Returns "" when there's nothing to show, matching topFoodsSection's
+// sibling behaviour of dropping empty sections from the layout entirely.
+func zeroPointSection(foods []api.FoodStat, w int) string {
+	if len(foods) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(sectionHeading("Zero-Point Foods Logged", "Zero-Point Foods", w))
+	b.WriteString("\n\n")
+
+	layout := zeroPointLayout(w)
+	for _, fs := range foods {
+		name := truncate(fs.Name, layout.nameW-2)
+		nameCol := lipgloss.NewStyle().Width(layout.nameW).Render(styleFoodItem.Render(name))
+		countCol := lipgloss.NewStyle().Width(foodCountW).Render(styleFoodPortion.Render(fmt.Sprintf("%d×", fs.Count)))
+		fmt.Fprintf(&b, "  %s%s", nameCol, countCol)
+		if layout.showKcal {
+			fmt.Fprint(&b, styleFoodPortion.Render(fmt.Sprintf("  %.0f kcal avg", fs.AvgCals)))
+		}
+		fmt.Fprintln(&b)
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // renderHeatmap draws a GitHub-contributions-style calendar grid: months

--- a/internal/tui/insights_layout.go
+++ b/internal/tui/insights_layout.go
@@ -1,0 +1,197 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Geometry for the Insights tab's responsive two-column layout (#74).
+//
+// insightsMinColWidth is Range Summary's own floor — its widest bar row is
+// roughly "  Points      <bar>  avg 36pt / 23pt target" (indent 2 + label 10
+// + gaps 4 + bar 6 + value ~24 = ~46; see barWidthForRows for how the exact
+// value width is measured rather than assumed). That floor is what the
+// two-column breakpoint derives from, rather than being a bare literal: a
+// column only appears once it can fit Range Summary's minimum bar width,
+// which in practice puts the breakpoint at a 100-column terminal (vw =
+// width-4 >= 96, colW = (vw-4)/2).
+const (
+	insightsGutter      = 4  // columns between the two content columns
+	insightsMinColWidth = 46 // Range Summary's floor, see comment above
+	insightsMinBarWidth = 6
+	insightsMaxBarWidth = 22 // today's shared bar-width ceiling
+)
+
+// insightsColumns reports the per-column content width and whether the
+// two-column layout applies. Two columns only when each gets at least
+// insightsMinColWidth.
+func insightsColumns(vw int) (colW int, twoCol bool) {
+	candidate := (vw - insightsGutter) / 2
+	if candidate < insightsMinColWidth {
+		return vw, false
+	}
+	return candidate, true
+}
+
+// blockWidth returns the width of a multi-line block's widest line — used to
+// measure the heatmap's actual rendered width (it doesn't stretch to fill
+// vw; see renderHeatmap) so render() can decide whether it fits beside Range
+// Summary on the same row.
+func blockWidth(s string) int {
+	w := 0
+	for _, line := range strings.Split(s, "\n") {
+		if lw := lipgloss.Width(line); lw > w {
+			w = lw
+		}
+	}
+	return w
+}
+
+// barWidthForRows computes one bar width shared by every row builder passed
+// in, wide enough that each row — including its own value text, which
+// varies with the data (bigger numbers, longer units) — fits within w. Each
+// builder is measured once at barWidth 1 rather than 0: makeBar (nutrition.go)
+// always appends a trailing "│" reference marker outside the width it's
+// given, but returns "" outright for width 0 — so a width-0 measurement
+// would miss that marker entirely and every row would come out one column
+// too wide. Measuring at 1 keeps the marker in the sample; since each
+// further unit of bar width adds exactly one more fill/empty cell, the
+// real bar width is a direct +1 offset from there.
+func barWidthForRows(w int, rows ...func(barWidth int) string) int {
+	maxAtOne := 0
+	for _, row := range rows {
+		if lw := lipgloss.Width(row(1)); lw > maxAtOne {
+			maxAtOne = lw
+		}
+	}
+	return clampBarWidth(w - maxAtOne + 1)
+}
+
+func clampBarWidth(bw int) int {
+	if bw > insightsMaxBarWidth {
+		return insightsMaxBarWidth
+	}
+	if bw < insightsMinBarWidth {
+		return insightsMinBarWidth
+	}
+	return bw
+}
+
+// sectionHeading renders a "<title>\n<rule>" block at width w, falling back
+// to the short title when the long one doesn't fit.
+func sectionHeading(long, short string, w int) string {
+	title := long
+	if lipgloss.Width(title) > w {
+		title = short
+	}
+	ruleWidth := w - 2
+	if ruleWidth < 1 {
+		ruleWidth = 1
+	}
+	sep := styleDim.Render(strings.Repeat("─", ruleWidth))
+	return styleMealHeading.Render(title) + "\n" + sep
+}
+
+// padBlock pads every line of s to exactly w cells, ANSI-truncating any line
+// that overruns. Safe to use with bare spaces here specifically because
+// every style the Insights tab touches is foreground-only (see makeBar,
+// renderHeatmap, and the style vars in styles.go) — the moment any Insights
+// style gains a Background(), every pad in this file becomes a black gap
+// (see CLAUDE.md's v1.15.1 notes) and must instead adopt help.go's
+// per-fragment Background() treatment.
+func padBlock(s string, w int) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		switch lw := lipgloss.Width(l); {
+		case lw < w:
+			lines[i] = l + strings.Repeat(" ", w-lw)
+		case lw > w:
+			lines[i] = ansi.Truncate(l, w, "")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// joinColumns places two section blocks side by side, left padded to leftW
+// and right to rightW (independent widths so the heatmap, which keeps its
+// own natural width rather than a shared colW, can still pair with a wider
+// Range Summary column). The gutter is folded into the left column's pad.
+// If one side is blank — an empty section, e.g. no micronutrient data — the
+// surviving side keeps its own width rather than expanding to fill the row,
+// so column boundaries stay aligned across the rows above and below it.
+func joinColumns(left string, leftW int, right string, rightW int) string {
+	leftBlank, rightBlank := strings.TrimSpace(left) == "", strings.TrimSpace(right) == ""
+	switch {
+	case leftBlank && rightBlank:
+		return ""
+	case rightBlank:
+		return padBlock(left, leftW)
+	case leftBlank:
+		return padBlock(right, rightW)
+	default:
+		return lipgloss.JoinHorizontal(lipgloss.Top,
+			padBlock(left, leftW+insightsGutter),
+			padBlock(right, rightW),
+		)
+	}
+}
+
+// foodRowLayout describes which columns a food-table row has room for at a
+// given allotted width — see topFoodsLayout/zeroPointLayout.
+type foodRowLayout struct {
+	nameW      int
+	showAvgPts bool
+	showKcal   bool
+}
+
+const (
+	foodIndentW   = 2
+	foodNameW     = 34 // Width() of the name column at full size
+	foodCountW    = 5
+	foodTotalPtsW = 14
+	foodAvgPtsW   = 12
+	foodKcalW     = 15 // "  1234 kcal avg"
+	foodNameMinW  = 16 // floor below which a truncated name stops being useful
+)
+
+// topFoodsLayout tiers Top Foods' columns by allotted width, shedding the
+// least essential ones first: kcal average, then points average, then
+// finally shrinking the name column down to foodNameMinW.
+func topFoodsLayout(w int) foodRowLayout {
+	const fixed = foodIndentW + foodCountW + foodTotalPtsW // 21
+	switch {
+	case w >= fixed+foodNameW+foodAvgPtsW+foodKcalW: // >= 82: full row
+		return foodRowLayout{foodNameW, true, true}
+	case w >= fixed+foodNameW+foodAvgPtsW: // >= 67: drop kcal avg
+		return foodRowLayout{foodNameW, true, false}
+	case w >= fixed+foodNameW: // >= 55: drop pt avg too
+		return foodRowLayout{foodNameW, false, false}
+	default: // shrink the name column last
+		nameW := w - fixed
+		if nameW < foodNameMinW {
+			nameW = foodNameMinW
+		}
+		return foodRowLayout{nameW, false, false}
+	}
+}
+
+// zeroPointLayout mirrors topFoodsLayout for the Zero-Point Foods table,
+// which has no points columns to shed — only the kcal average and, at the
+// narrowest widths, the name column.
+func zeroPointLayout(w int) foodRowLayout {
+	const fixed = foodIndentW + foodCountW // 7
+	switch {
+	case w >= fixed+foodNameW+foodKcalW: // >= 56: full row
+		return foodRowLayout{foodNameW, false, true}
+	case w >= fixed+foodNameW: // >= 41: drop kcal avg
+		return foodRowLayout{foodNameW, false, false}
+	default:
+		nameW := w - fixed
+		if nameW < foodNameMinW {
+			nameW = foodNameMinW
+		}
+		return foodRowLayout{nameW, false, false}
+	}
+}

--- a/internal/tui/insights_layout_test.go
+++ b/internal/tui/insights_layout_test.go
@@ -1,0 +1,188 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func TestInsightsColumns(t *testing.T) {
+	tests := []struct {
+		vw         int
+		wantColW   int
+		wantTwoCol bool
+	}{
+		{vw: 40, wantColW: 40, wantTwoCol: false},
+		{vw: 95, wantColW: 95, wantTwoCol: false}, // width 99: single column
+		{vw: 96, wantColW: 46, wantTwoCol: true},  // width 100: breakpoint
+		{vw: 97, wantColW: 46, wantTwoCol: true},
+		{vw: 116, wantColW: 56, wantTwoCol: true},
+	}
+	for _, tt := range tests {
+		colW, twoCol := insightsColumns(tt.vw)
+		if colW != tt.wantColW || twoCol != tt.wantTwoCol {
+			t.Errorf("insightsColumns(%d) = (%d,%v), want (%d,%v)", tt.vw, colW, twoCol, tt.wantColW, tt.wantTwoCol)
+		}
+	}
+}
+
+func TestClampBarWidth(t *testing.T) {
+	tests := []struct{ bw, want int }{
+		{bw: -5, want: insightsMinBarWidth},
+		{bw: 0, want: insightsMinBarWidth},
+		{bw: insightsMinBarWidth, want: insightsMinBarWidth},
+		{bw: 12, want: 12},
+		{bw: insightsMaxBarWidth, want: insightsMaxBarWidth},
+		{bw: 200, want: insightsMaxBarWidth},
+	}
+	for _, tt := range tests {
+		if got := clampBarWidth(tt.bw); got != tt.want {
+			t.Errorf("clampBarWidth(%d) = %d, want %d", tt.bw, got, tt.want)
+		}
+	}
+}
+
+func TestBarWidthForRows(t *testing.T) {
+	row := func(prefixWidth int) func(int) string {
+		return func(bw int) string {
+			return strings.Repeat("x", prefixWidth) + strings.Repeat("#", bw)
+		}
+	}
+
+	tests := []struct {
+		name string
+		w    int
+		rows []func(int) string
+		want int
+	}{
+		{"single row, room to spare", 50, []func(int) string{row(20)}, insightsMaxBarWidth},
+		{"single row, tight", 26, []func(int) string{row(20)}, insightsMinBarWidth},
+		{"widest row wins", 50, []func(int) string{row(10), row(30)}, 20},
+		{"no rows uses full width, clamped to max", 50, nil, insightsMaxBarWidth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := barWidthForRows(tt.w, tt.rows...); got != tt.want {
+				t.Errorf("barWidthForRows(%d, ...) = %d, want %d", tt.w, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTopFoodsLayout(t *testing.T) {
+	tests := []struct {
+		w              int
+		wantNameW      int
+		wantShowAvgPts bool
+		wantShowKcal   bool
+	}{
+		{82, foodNameW, true, true},
+		{81, foodNameW, true, false},
+		{67, foodNameW, true, false},
+		{66, foodNameW, false, false},
+		{55, foodNameW, false, false},
+		{54, 33, false, false},
+		{40, 19, false, false},
+		{20, foodNameMinW, false, false},
+	}
+	for _, tt := range tests {
+		got := topFoodsLayout(tt.w)
+		if got.nameW != tt.wantNameW || got.showAvgPts != tt.wantShowAvgPts || got.showKcal != tt.wantShowKcal {
+			t.Errorf("topFoodsLayout(%d) = %+v, want {%d,%v,%v}", tt.w, got, tt.wantNameW, tt.wantShowAvgPts, tt.wantShowKcal)
+		}
+	}
+}
+
+func TestZeroPointLayout(t *testing.T) {
+	tests := []struct {
+		w            int
+		wantNameW    int
+		wantShowKcal bool
+	}{
+		{56, foodNameW, true},
+		{55, foodNameW, false},
+		{41, foodNameW, false},
+		{40, 33, false},
+		{20, foodNameMinW, false},
+	}
+	for _, tt := range tests {
+		got := zeroPointLayout(tt.w)
+		if got.nameW != tt.wantNameW || got.showKcal != tt.wantShowKcal {
+			t.Errorf("zeroPointLayout(%d) = %+v, want {%d,_,%v}", tt.w, got, tt.wantNameW, tt.wantShowKcal)
+		}
+	}
+}
+
+func TestPadBlock(t *testing.T) {
+	styled := styleDetailLabel.Render("Points") + makeBar(3, 10, 8, false)
+	natural := lipgloss.Width(styled)
+
+	for _, w := range []int{natural + 5, natural, natural - 3} {
+		got := padBlock(styled, w)
+		for _, line := range strings.Split(got, "\n") {
+			if lw := lipgloss.Width(line); lw != w {
+				t.Errorf("padBlock(_, %d): line width = %d, want %d", w, lw, w)
+			}
+		}
+	}
+}
+
+func TestJoinColumns(t *testing.T) {
+	tall := "a\nb\nc"
+	short := "x"
+
+	t.Run("both non-empty", func(t *testing.T) {
+		got := joinColumns(short, 10, tall, 10)
+		lines := strings.Split(got, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("height = %d, want 3", len(lines))
+		}
+		wantWidth := 10 + insightsGutter + 10
+		for _, l := range lines {
+			if lipgloss.Width(l) != wantWidth {
+				t.Errorf("line width = %d, want %d", lipgloss.Width(l), wantWidth)
+			}
+		}
+	})
+
+	t.Run("right empty keeps left's own width", func(t *testing.T) {
+		got := joinColumns(short, 10, "", 20)
+		if lipgloss.Width(got) != 10 {
+			t.Errorf("width = %d, want 10 (left's width, not expanded)", lipgloss.Width(got))
+		}
+	})
+
+	t.Run("left empty keeps right's own width", func(t *testing.T) {
+		got := joinColumns("", 10, short, 20)
+		if lipgloss.Width(got) != 20 {
+			t.Errorf("width = %d, want 20 (right's width, not expanded)", lipgloss.Width(got))
+		}
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		if got := joinColumns("", 10, "  ", 20); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestSectionHeading(t *testing.T) {
+	long, short := "A Very Long Section Title", "Short"
+	tests := []struct {
+		w         int
+		wantTitle string
+	}{
+		{w: 100, wantTitle: long},
+		{w: lipgloss.Width(long), wantTitle: long},
+		{w: lipgloss.Width(long) - 1, wantTitle: short},
+		{w: 2, wantTitle: short}, // narrower than even the short form
+	}
+	for _, tt := range tests {
+		got := sectionHeading(long, short, tt.w)
+		firstLine := strings.SplitN(got, "\n", 2)[0]
+		if !strings.Contains(firstLine, tt.wantTitle) {
+			t.Errorf("sectionHeading(_,_,%d) first line = %q, want to contain %q", tt.w, firstLine, tt.wantTitle)
+		}
+	}
+}

--- a/internal/tui/insights_test.go
+++ b/internal/tui/insights_test.go
@@ -1,0 +1,164 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/ali5ter/wwlog/internal/api"
+)
+
+// insightsFixtureLogs builds n days of data with points, meals across every
+// period, and full nutrition — enough for every Insights section (heatmap,
+// range summary, meals, macros, micros, top foods, zero-point foods) to
+// render non-empty.
+func insightsFixtureLogs(n int) []*api.DayLog {
+	nutriEntry := func(name string, pts, cals, protein, carbs, fat float64) api.FoodEntry {
+		return api.FoodEntry{
+			Name:          name,
+			PortionSize:   1,
+			PointsPrecise: pts,
+			DefaultPortion: api.DefaultPortion{
+				Size: 1,
+				Nutrition: api.NutritionMap{
+					"calories":     cals,
+					"protein":      protein,
+					"carbs":        carbs,
+					"fat":          fat,
+					"fiber":        5,
+					"sodium":       400,
+					"addedSugar":   4,
+					"saturatedFat": 3,
+				},
+			},
+		}
+	}
+	logs := make([]*api.DayLog, n)
+	for i := 0; i < n; i++ {
+		logs[i] = &api.DayLog{
+			Date: fmt.Sprintf("2026-06-%02d", i%28+1),
+			Points: api.DayPoints{
+				DailyTarget:              23,
+				WeeklyAllowanceRemaining: 20,
+			},
+			Meals: api.Meals{
+				Morning: []api.FoodEntry{nutriEntry("Oatmeal With Berries", 6, 300, 10, 50, 5)},
+				Midday:  []api.FoodEntry{nutriEntry("Grilled Chicken Salad", 8, 450, 35, 20, 15)},
+				Evening: []api.FoodEntry{nutriEntry("Salmon And Rice Bowl", 9, 600, 40, 60, 20)},
+				Anytime: []api.FoodEntry{nutriEntry("Apple", 0, 95, 0, 25, 0)},
+			},
+		}
+	}
+	return logs
+}
+
+// insightsEmptyNutritionLogs has food entries with points but no nutrition
+// data — Macro Distribution and Daily Averages both have nothing to show.
+func insightsEmptyNutritionLogs(n int) []*api.DayLog {
+	logs := make([]*api.DayLog, n)
+	for i := 0; i < n; i++ {
+		logs[i] = &api.DayLog{
+			Date:   fmt.Sprintf("2026-06-%02d", i%28+1),
+			Points: api.DayPoints{DailyTarget: 23, WeeklyAllowanceRemaining: 20},
+			Meals: api.Meals{
+				Anytime: []api.FoodEntry{{Name: "Mystery Snack", PointsPrecise: 0}},
+			},
+		}
+	}
+	return logs
+}
+
+func TestInsightsRenderFitsWidth(t *testing.T) {
+	logs := insightsFixtureLogs(14)
+	// 40 (insightsViewWidth's absolute floor) is deliberately excluded: a
+	// bar row's label and value text plus the insightsMinBarWidth=6 floor
+	// can genuinely not fit in 40 columns without either eliding text or
+	// shrinking the minimum readable bar below 6 cells — neither of which
+	// this design does. The heatmap's legend line (~56 wide, independent of
+	// vw — see renderHeatmap) has the same unavoidable floor. Both are
+	// pre-existing at-the-margin behaviour, not something this refactor
+	// introduced or is expected to fix; 60 and up is the realistic range.
+	widths := []int{60, 79, 85, 99, 100, 101, 109, 110, 120, 200}
+
+	for _, w := range widths {
+		m := newInsightsModel(logs, w, 30)
+		vw := insightsViewWidth(w)
+		for i, line := range strings.Split(m.render(), "\n") {
+			if lw := lipgloss.Width(line); lw > vw {
+				t.Errorf("width %d: line %d width = %d, exceeds vw = %d\nline: %q", w, i, lw, vw, line)
+			}
+		}
+	}
+}
+
+func TestInsightsSingleColumnBelowBreakpoint(t *testing.T) {
+	logs := insightsFixtureLogs(14)
+	m := newInsightsModel(logs, 99, 30)
+	for _, line := range strings.Split(m.render(), "\n") {
+		if strings.Contains(line, "Range Summary") && strings.Contains(line, "Points by Meal") {
+			t.Errorf("width 99 should be single-column, but a line pairs Range Summary with Points by Meal: %q", line)
+		}
+	}
+}
+
+func TestInsightsTwoColumnAtBreakpoint(t *testing.T) {
+	logs := insightsFixtureLogs(14)
+	m := newInsightsModel(logs, 104, 30) // twoCol but not wide enough to pair with the heatmap
+	found := false
+	for _, line := range strings.Split(m.render(), "\n") {
+		if strings.Contains(line, "Range Summary") && strings.Contains(line, "Points by Meal") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("width 104 should pair Range Summary with Points by Meal on one line")
+	}
+}
+
+func TestInsightsWideRowPairsHeatmapWithSummary(t *testing.T) {
+	logs := insightsFixtureLogs(14)
+
+	m109 := newInsightsModel(logs, 109, 30)
+	for _, line := range strings.Split(m109.render(), "\n") {
+		if strings.Contains(line, "Points Budget") && strings.Contains(line, "Range Summary") {
+			t.Error("width 109 should not yet be wide enough to pair the heatmap with Range Summary")
+		}
+	}
+
+	m110 := newInsightsModel(logs, 110, 30)
+	found := false
+	for _, line := range strings.Split(m110.render(), "\n") {
+		if strings.Contains(line, "Points Budget") && strings.Contains(line, "Range Summary") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("width 110 should pair the heatmap with Range Summary on one line")
+	}
+}
+
+func TestInsightsEmptySectionsKeepColumn(t *testing.T) {
+	logs := insightsEmptyNutritionLogs(14)
+	// Width 104 lands in the non-wide two-column tier, where Macro
+	// Distribution pairs with Daily Averages (see render()) — the pairing
+	// this test needs to exercise the empty-micros collapse.
+	const width = 104
+	m := newInsightsModel(logs, width, 30)
+	colW, twoCol := insightsColumns(insightsViewWidth(width))
+	if !twoCol {
+		t.Fatal("setup: width 104 should be two-column")
+	}
+
+	rendered := m.render()
+	if strings.Contains(rendered, "\x00") {
+		t.Fatal("render() produced an unexpected null byte")
+	}
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "Macro Distribution") {
+			if lw := lipgloss.Width(line); lw > colW {
+				t.Errorf("Macro Distribution with an empty pairing should stay at colW = %d, got line width %d", colW, lw)
+			}
+		}
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -42,6 +42,9 @@ func newDateList(items []list.Item, width, height int) list.Model {
 }
 
 func truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
 	r := []rune(s)
 	if len(r) <= max {
 		return s


### PR DESCRIPTION
## Summary
- Reflow the Insights tab into two columns above a 100-column terminal (derived from Range Summary's own minimum bar-row width, not a bare literal) and, above ~110 columns, pair the heatmap with Range Summary instead of leaving the rest of its row empty
- All seven sections now render to an arbitrary allotted width instead of a single tab-wide bar width, composed with lipgloss.JoinHorizontal the same way help.go already hand-rolls its column layout — no new dependency
- Top Foods and Zero-Point Foods shed columns as their width shrinks rather than silently clipping, which is what they did before below ~86 columns

Closes #74

🤖 Generated with [claude-workflow-skills:promote](https://github.com/ali5ter/claude-workflow-skills) on behalf of [Alister](https://github.com/ali5ter)